### PR TITLE
[Fix] 회원가입 및 로그인 유효성 검사 추가

### DIFF
--- a/worlds-fe-v20/Models/APIErrorResponse.swift
+++ b/worlds-fe-v20/Models/APIErrorResponse.swift
@@ -6,7 +6,7 @@
 //
 
 struct APIErrorResponse: Codable {
-    let message: [String]?
+    let message: [String]
     let error: String
     let statusCode: Int
 }

--- a/worlds-fe-v20/Services/UserAPIManager.swift
+++ b/worlds-fe-v20/Services/UserAPIManager.swift
@@ -110,21 +110,16 @@ class UserAPIManager {
         case .failure:
             if let rawData = dataResponse.data,
                let rawString = String(data: rawData, encoding: .utf8) {
-                print("서버 원본 응답: \(rawString)")
+                // print("회원가입 서버 원본 응답: \(rawString)")
                 
-                do {
-                    let errorResponse = try JSONDecoder().decode(APIErrorResponse.self, from: rawData)
-                    print("파싱된 에러 응답: \(errorResponse)")
-                    
-                    var errorMessage = errorResponse.error
-                    
-                    throw UserAPIError.serverError(message: errorMessage)
-                } catch {
-                    print("에러 응답 파싱 실패: \(error)")
-                    throw UserAPIError.serverError(message: "signUp 서버 응답 파싱 실패")
-                }
+                // 서버 에러 응답 파싱 시도
+                let errorResponse = try JSONDecoder().decode(APIErrorResponse.self, from: rawData)
+                print("회원가입 파싱된 에러 응답: \(errorResponse)")
+                
+                let errorMessage = errorResponse.message[0]
+                throw UserAPIError.serverError(message: errorMessage)
             } else {
-                throw UserAPIError.serverError(message: "signUp 서버 응답 파싱 실패")
+                throw UserAPIError.serverError(message: "signup 서버 응답 파싱 실패")
             }
         }
     }
@@ -166,20 +161,14 @@ class UserAPIManager {
         case .failure:
             if let rawData = dataResponse.data,
                let rawString = String(data: rawData, encoding: .utf8) {
-                print("로그인 서버 원본 응답: \(rawString)")
+                // print("로그인 서버 원본 응답: \(rawString)")
                 
                 // 서버 에러 응답 파싱 시도
-                do {
-                    let errorResponse = try JSONDecoder().decode(APIErrorResponse.self, from: rawData)
-                    print("로그인 파싱된 에러 응답: \(errorResponse)")
-                    
-                    var errorMessage = errorResponse.error
-                    
-                    throw UserAPIError.serverError(message: errorMessage)
-                } catch {
-                    print("로그인 에러 응답 파싱 실패: \(error)")
-                    throw UserAPIError.serverError(message: "login 서버 응답 파싱 실패")
-                }
+                let errorResponse = try JSONDecoder().decode(APIErrorResponse.self, from: rawData)
+                print("로그인 파싱된 에러 응답: \(errorResponse)")
+                
+                let errorMessage = errorResponse.message[0]
+                throw UserAPIError.serverError(message: errorMessage)
             } else {
                 throw UserAPIError.serverError(message: "login 서버 응답 파싱 실패")
             }

--- a/worlds-fe-v20/ViewModels/LoginViewModel.swift
+++ b/worlds-fe-v20/ViewModels/LoginViewModel.swift
@@ -15,17 +15,23 @@ final class LoginViewModel: ObservableObject {
     
     // 로그인 함수
     @MainActor
-    func login() async {
+    func login() async -> Bool {
         do {
             let user = try await UserAPIManager.shared.login(email: email, password: password)
             print("로그인 정보: \(user)")
             self.errorMessage = nil
+            
+            return true
         } catch UserAPIError.serverError(let message) {
             self.errorMessage = message
-            print(message)
+            print("서버 에러: \(message)")
+            
+            return false
         } catch {
             self.errorMessage = "로그인 실패: \(error.localizedDescription)"
-            print(errorMessage)
+            print("기타 에러: \(errorMessage)")
+            
+            return false
         }
     }
 }

--- a/worlds-fe-v20/ViewModels/SignUpViewModel.swift
+++ b/worlds-fe-v20/ViewModels/SignUpViewModel.swift
@@ -21,17 +21,23 @@ final class SignUpViewModel: ObservableObject {
     
     // 회원가입 함수
     @MainActor
-    func signup() async {
+    func signup() async -> Bool {
         do {
             let user = try await UserAPIManager.shared.signUp(name: name, email: email, password: password, birth: birthDate, isMentor: isMentor, mentorCode: mentorCode)
             print("회원 가입 정보: \(user)")
             self.errorMessage = nil
+            
+            return true
         } catch UserAPIError.serverError(let message) {
             self.errorMessage = message
             print(message)
+            
+            return false
         } catch {
             self.errorMessage = "회원가입 실패: \(error.localizedDescription)"
             print(errorMessage)
+            
+            return false
         }
     }
     

--- a/worlds-fe-v20/Views/Common/CommonSignUpTextField.swift
+++ b/worlds-fe-v20/Views/Common/CommonSignUpTextField.swift
@@ -32,6 +32,7 @@ struct CommonSignUpTextField: View {
 
             } else {
                 TextField("\(placeholder)", text: $content)
+                    .textInputAutocapitalization(.never) // 자동 대문자처리 해제
                     .foregroundStyle(Color.gray)
                     .font(.system(size: 20))
                     .frame(height: 60)

--- a/worlds-fe-v20/Views/Login/LoginView.swift
+++ b/worlds-fe-v20/Views/Login/LoginView.swift
@@ -33,6 +33,7 @@ struct LoginView: View {
                     .padding(.bottom, 80)
                 
                 TextField("이메일을 입력하세요", text: $email)
+                    .textInputAutocapitalization(.never) // 자동 대문자처리 해제
                     .keyboardType(.emailAddress)
                     .foregroundStyle(Color.gray)
                     .font(.system(size: 20))

--- a/worlds-fe-v20/Views/Login/LoginView.swift
+++ b/worlds-fe-v20/Views/Login/LoginView.swift
@@ -52,28 +52,35 @@ struct LoginView: View {
                     .padding(.bottom, 20)
                 
                 Button {
-//                    if email.isEmpty || password.isEmpty {
-//                        alertMessage = "이메일과 비밀번호를 모두 입력해주세요."
-//                        showAlert = true
-//                    } else if !isValidEmail(email) {
-//                        alertMessage = "이메일 형식이 올바르지 않습니다."
-//                        showAlert = true
-//                    } else {
-//                        // 로그인 진행
-//                        appState.flow = .main
-//                    }
-                    
-                    viewModel.email = email
-                    viewModel.password = password
+                    if email.isEmpty || password.isEmpty {
+                        alertMessage = "이메일과 비밀번호를 모두 입력해주세요."
+                        showAlert = true
+                    } else if !isValidEmail(email) {
+                        alertMessage = "이메일 형식이 올바르지 않습니다."
+                        showAlert = true
+                    } else {
+                        viewModel.email = email
+                        viewModel.password = password
+                        
+                        Task {
+                            let isLoggedIn = await viewModel.login()
+                            
+                            if isLoggedIn {
+                                appState.flow = .main
+                            } else {
+                                // 401 -> 이메일이나 비번이 바르지 않을 경우
+                                // 400 -> 이메일 제대로, 비밀번호 틀렸을 경우
+                                // APIErrorResponse(message: Optional(["비밀번호는 영문, 숫자, 특수문자 중 2가지 이상 조합으로 8~16자여야 합니다."]), error: "Bad Request", statusCode: 400)
+                                // 그 외 이메일 형식 검사 및 빈 필드는 프론트에서 처리
+                                showAlert = true
+                                alertMessage = viewModel.errorMessage ?? "알 수 없는 에러 발생"
+                            }
+                        }
+                    }
                     
                     print("loginView: \(viewModel.email)")
                     print("loginView: \(viewModel.password)")
                     
-                    Task {
-                        await viewModel.login()
-                        
-                        appState.flow = .main
-                    }
                 } label: {
                     ZStack {
                         RoundedRectangle(cornerRadius: 16)
@@ -87,10 +94,8 @@ struct LoginView: View {
                             .fontWeight(.semibold)
                     }
                 }
-                .alert("오류", isPresented: $showAlert) {
+                .alert(alertMessage, isPresented: $showAlert) {
                     Button("확인", role: .cancel) { }
-                } message: {
-                    Text(alertMessage)
                 }
                 .disabled(!isFilled)
                 .padding(.bottom, 40)

--- a/worlds-fe-v20/Views/SignUp/SignUpAccountView.swift
+++ b/worlds-fe-v20/Views/SignUp/SignUpAccountView.swift
@@ -16,14 +16,14 @@ struct SignUpAccountView: View {
     @State var password: String = ""
     @State var passwordCheck: String = ""
     
-//    var isFilled: Bool {
-//        !email.isEmpty &&
-//        isValidEmail(email) &&
-//        !password.isEmpty &&
-//        !passwordCheck.isEmpty &&
-//        password == passwordCheck
-//    }
-    var isFilled = true
+    var isFilled: Bool {
+        !email.isEmpty &&
+        isValidEmail(email) &&
+        !password.isEmpty &&
+        !passwordCheck.isEmpty &&
+        password == passwordCheck
+    }
+    // var isFilled = true
     @State var isSuceed: Bool = false
     
     @EnvironmentObject var viewModel: SignUpViewModel
@@ -37,20 +37,31 @@ struct SignUpAccountView: View {
                 
                 CommonSignUpTextField(title: "이메일", placeholder: "이메일을 입력해주세요", content: $email)
                     .keyboardType(.emailAddress)
-                    .padding(.bottom, 40)
                     .padding(.top, 40)
                 
-                //            if !email.isEmpty && !isValidEmail(email) {
-                //                Text("올바른 이메일 형식이 아닙니다.")
-                //                    .foregroundColor(.red)
-                //                    .font(.caption)
-                //            }
+                if !email.isEmpty && !isValidEmail(email) {
+                    Text("올바른 이메일 형식이 아닙니다.")
+                        .foregroundColor(.red)
+                        .font(.caption)
+                }
                 
                 CommonSignUpTextField(title: "비밀번호", placeholder: "비밀번호를 입력해주세요", isSecure: true, content: $password)
-                    .padding(.bottom, 40)
+                    .padding(.top, 40)
+                
+                if !password.isEmpty && !isValidPassword(password) {
+                    Text("비밀번호는 영문, 숫자, 특수문자 중 2가지 이상 조합으로 8~16자여야 합니다.")
+                        .foregroundColor(.red)
+                        .font(.caption)
+                }
                 
                 CommonSignUpTextField(title: "비밀번호 확인", placeholder: "비밀번호를 한 번 더 입력해주세요.", isSecure: true, content: $passwordCheck)
-                    .padding(.bottom, 40)
+                    .padding(.top, 40)
+                
+                if !passwordCheck.isEmpty && password != passwordCheck {
+                    Text("비밀번호가 일치하지 않습니다.")
+                        .foregroundColor(.red)
+                        .font(.caption)
+                }
                 
                 Spacer()
                 
@@ -65,6 +76,7 @@ struct SignUpAccountView: View {
                     // viewModel 호출 후 화면 전환 (어떤 방식이 더 효율적인지는 아직 모르겠음)
                     isSuceed = true
                 }
+                .padding(.top, 40)
                 .padding(.bottom, 12)
             }
             
@@ -97,12 +109,45 @@ struct SignUpAccountView: View {
         }
         .hideKeyboardOnTap()
     }
-    
+}
+
+extension SignUpAccountView {
     func isValidEmail(_ email: String) -> Bool {
         let emailRegEx =
         #"^[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$"#
 
         return NSPredicate(format: "SELF MATCHES %@", emailRegEx).evaluate(with: email)
+    }
+
+    func isValidPassword(_ password: String) -> Bool {
+        // 길이 검사 (8자 이상 ~ 16자 이하)
+        guard password.count >= 8 && password.count <= 16 else {
+            return false
+        }
+        
+        // 포함 조건 개수 세기
+        var conditionsMet = 0
+        
+        // 영문 포함 여부 (대소문자 구분 없음)
+        let letterRegex = ".*[A-Za-z]+.*"
+        if NSPredicate(format: "SELF MATCHES %@", letterRegex).evaluate(with: password) {
+            conditionsMet += 1
+        }
+        
+        // 숫자 포함 여부
+        let numberRegex = ".*[0-9]+.*"
+        if NSPredicate(format: "SELF MATCHES %@", numberRegex).evaluate(with: password) {
+            conditionsMet += 1
+        }
+        
+        // 특수문자 포함 여부 (영문,숫자 제외 모든 문자 포함)
+        let specialCharRegex = ".*[^A-Za-z0-9]+.*"
+        if NSPredicate(format: "SELF MATCHES %@", specialCharRegex).evaluate(with: password) {
+            conditionsMet += 1
+        }
+        
+        // 최소 2가지 조건 이상 만족해야 함
+        return conditionsMet >= 2
     }
 }
 

--- a/worlds-fe-v20/Views/SignUp/SignUpDetailProfileView.swift
+++ b/worlds-fe-v20/Views/SignUp/SignUpDetailProfileView.swift
@@ -20,7 +20,12 @@ struct SignUpDetailProfileView: View {
     @State var birthDay: Int = Calendar.current.component(.day, from: Date())
     
     @State var isDatePickerPresented: Bool = false
-    @State var isFilled: Bool = true
+    
+    // @State var isFilled: Bool = true
+    var isFilled: Bool {
+        !name.isEmpty &&
+        !phoneNumber.isEmpty
+    }
     
     @State private var showAlert = false
     @State private var alertMessage = ""

--- a/worlds-fe-v20/Views/SignUp/SignUpDetailProfileView.swift
+++ b/worlds-fe-v20/Views/SignUp/SignUpDetailProfileView.swift
@@ -22,6 +22,9 @@ struct SignUpDetailProfileView: View {
     @State var isDatePickerPresented: Bool = false
     @State var isFilled: Bool = true
     
+    @State private var showAlert = false
+    @State private var alertMessage = ""
+    
     @EnvironmentObject var viewModel: SignUpViewModel
     var body: some View {
         VStack {
@@ -137,8 +140,15 @@ struct SignUpDetailProfileView: View {
                 print("signup Detail View: \(viewModel.isMentor)")
                 
                 Task {
-                    await viewModel.signup()
-                    appState.flow = .login
+                    let isSignIn = await viewModel.signup()
+                    
+                    if isSignIn {
+                        // 확인 버튼 액션
+                        appState.flow = .login
+                    } else {
+                        showAlert = true
+                        alertMessage = viewModel.errorMessage ?? "알 수 없는 에러 발생"
+                    }
                 }
             }
             .padding(.bottom, 12)
@@ -150,6 +160,9 @@ struct SignUpDetailProfileView: View {
                     .foregroundStyle(Color.gray)
                     .font(.system(size: 14))
             }
+        }
+        .alert(alertMessage, isPresented: $showAlert) {
+            Button("확인", role: .cancel) { }
         }
         .padding()
         .background(.backgroundws)


### PR DESCRIPTION
## 📄 작업 내용
#### 회원가입
- 이메일, 비밀번호 유효성 검사 코드 추가했습니다.
- 이메일, 비밀번호 조건에 맞지 않을 경우, 사용자가 알 수 있도록 처리했습니다.
- 모든 필드 미입력시 하단 버튼 비활성화 처리 했습니다.
- 회원가입 성공 시에만 화면 전환이 일어나고, 아닐 경우 알림창이 뜨도록 설정했습니다.

#### 로그인
- 모든 필드 미입력시 로그인 버튼 비활성화 처리 했습니다.
- 로그인 성공 시에만 화면 전환이 일어나고, 아닐 경우 알림창이 뜨도록 설정했습니다.

<img width="250" alt="image" src="https://github.com/user-attachments/assets/1dbc7c07-fe8b-432c-a4ba-81d04beabcc8" />

<img width="250" alt="image" src="https://github.com/user-attachments/assets/bf7a106a-8d53-47a2-a97c-f267c2a1b4bf" />


## 💻 주요 코드 설명
`SignUpAccountView.swift`
- isFilled를 통해 각 필드 조건 검사 진행했습니다.
- isValidEmail, isValidPassword 함수를 통해 이메일, 비밀번호 유효성 검사 처리 했습니다.
- 이후 사용자가 확인할 수 있도록 Text를 띄웠습니다.
```swift
var isFilled: Bool {
    !email.isEmpty &&
    isValidEmail(email) &&
    !password.isEmpty &&
    !passwordCheck.isEmpty &&
    password == passwordCheck
}

if !password.isEmpty && !isValidPassword(password) {
    Text("비밀번호는 영문, 숫자, 특수문자 중 2가지 이상 조합으로 8~16자여야 합니다.")
        .foregroundColor(.red)
        .font(.caption)
}
```

`LoginView.swift`
- 로그인 성공을 하지 못한 경우 Alert 창이 뜨도록 수정했습니다.
```swift
if isLoggedIn {
    appState.flow = .main
} else {
    // 401 -> 이메일이나 비번이 바르지 않을 경우
    // 400 -> 이메일 제대로, 비밀번호 틀렸을 경우
    // APIErrorResponse(message: Optional(["비밀번호는 영문, 숫자, 특수문자 중 2가지 이상 조합으로 8~16자여야 합니다."]), error: "Bad Request", statusCode: 400)
    // 그 외 이메일 형식 검사 및 빈 필드는 프론트에서 처리
    showAlert = true
    alertMessage = viewModel.errorMessage ?? "알 수 없는 에러 발생"
}
```

## 💬 공유사항 to 리뷰어
- 모든 필드 입력을 확인하고는 있지만, 휴대폰 번호의 경우 번호 형식 검사는 하지 않고 필드 입력 유무만 확인하고 있습니다.

Closes #13 
