### PR TITLE
[feature] 탭 제스처로 키보드 내리기 기능 추가

### DIFF
--- a/worlds-fe-v20/UIExtensions.swift
+++ b/worlds-fe-v20/UIExtensions.swift
@@ -1,0 +1,14 @@
+//
+//  UIExtensions.swift
+//  worlds-fe-v20
+//
+//  Created by 이서하 on 7/24/25.
+//
+
+import UIKit
+
+extension UIApplication {
+    func endEditing() {
+        sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
+    }
+}

--- a/worlds-fe-v20/Views/CreateQuestionView.swift
+++ b/worlds-fe-v20/Views/CreateQuestionView.swift
@@ -152,6 +152,9 @@ struct CreateQuestionView: View {
                 .padding(.horizontal, 4)
                 }
             } // ScrollView 끗
+            .onTapGesture {
+                UIApplication.shared.endEditing()
+            }
             
             .padding(.horizontal, 20)
             .navigationTitle("질문하기")


### PR DESCRIPTION
## 📄 작업 내용

- 게시물 쓰고 화면 아무데나 누르면 키보드 사라지게 했습니다.
- ScrollView에 .onTapGesture 적용
<img src="https://github.com/user-attachments/assets/7dc453bf-7598-4c3b-bed3-5de041868a1d" width="250">





## 💻 주요 코드 설명

`UIExtensions.swift` 추가

```swift
import UIKit

extension UIApplication {
    func endEditing() {
        sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
    }
}
```

`CreateQuestionView.swift` 
```swift
ScrollView{
...
        }
        .onTapGesture {
                UIApplication.shared.endEditing()
            }
```