### PR TITLE
[style] 게시판 목록, 게시글 작성, 질문 버튼 색 통일 및 패딩 조정

### DIFF
--- a/worlds-fe-v20/Views/CreateQuestionView.swift
+++ b/worlds-fe-v20/Views/CreateQuestionView.swift
@@ -61,7 +61,7 @@ struct CreateQuestionView: View {
                     .background(Color.white)
                     .overlay(
                         RoundedRectangle(cornerRadius: 8)
-                            .stroke(Color(red: 105/255, green: 131/255, blue: 255/255), lineWidth: 1)
+                            .stroke(Color.mainws, lineWidth: 1)
                     )
                     .font(.system(size: 17))
                     .padding(.horizontal, 4)
@@ -79,7 +79,7 @@ struct CreateQuestionView: View {
                         .background(Color.white)
                         .overlay(
                             RoundedRectangle(cornerRadius: 8)
-                                .stroke(Color(red: 105/255, green: 131/255, blue: 255/255), lineWidth: 1)
+                                .stroke(Color.mainws, lineWidth: 1)
                         )
                         .font(.system(size: 17))
                         .frame(height: 370)
@@ -105,7 +105,7 @@ struct CreateQuestionView: View {
                         .background(Color.white)
                         .overlay(
                             RoundedRectangle(cornerRadius: 10)
-                                .stroke(Color(red: 105/255, green: 131/255, blue: 255/255), lineWidth: 1.2)
+                                .stroke(Color.mainws, lineWidth: 1.2)
                         )
                     }
 
@@ -147,7 +147,7 @@ struct CreateQuestionView: View {
                         .font(.system(size: 18, weight: .semibold))
                         .foregroundColor(.white)
                         .frame(maxWidth: .infinity, minHeight: 48)
-                        .background(Color(red: 105/255, green: 131/255, blue: 255/255))
+                        .background(Color.mainws)
                         .cornerRadius(13)
                         .shadow(color: Color(.systemGray3), radius: 3, x: 0, y: 3)
                 }

--- a/worlds-fe-v20/Views/QuestionDetailView.swift
+++ b/worlds-fe-v20/Views/QuestionDetailView.swift
@@ -32,7 +32,7 @@ struct QuestionDetailView: View {
     ]
     
     let badgeColorMap: [String: Color] = [
-        "학습": .blue,
+        "학습": .mainws,
         "자유": .purple,
         "전체": .gray
     ]
@@ -181,7 +181,7 @@ struct QuestionDetailView: View {
                             .background(Color.white)
                             .overlay(
                                 RoundedRectangle(cornerRadius: 10)
-                                    .stroke(Color.brown, lineWidth: 1)
+                                    .stroke(Color.mainws, lineWidth: 1)
                             )
                             .focused($isTextFieldFocused)
                             
@@ -198,7 +198,7 @@ struct QuestionDetailView: View {
                                 Text("등록")
                                     .frame(minWidth: 60)
                                     .padding(.vertical, 12)
-                                    .background(Color.brown)
+                                    .background(Color.mainws)
                                     .foregroundColor(.white)
                                     .clipShape(RoundedRectangle(cornerRadius: 10))
                             }
@@ -260,7 +260,7 @@ struct QuestionDetailView: View {
             Button("취소", role: .cancel) {}
         }
     }
-
+    
     // 날짜 포맷터
     func formatDate(_ dateStr: String) -> String {
         let inputFormatter = ISO8601DateFormatter()

--- a/worlds-fe-v20/Views/QuestionView.swift
+++ b/worlds-fe-v20/Views/QuestionView.swift
@@ -71,41 +71,46 @@ struct QuestionView: View {
                     .padding(.top, 14)
                     
                     // 카테고리 선택
-                    ScrollView(.horizontal, showsIndicators: false) {
-                        HStack(spacing: 16) {
-                            ForEach(categories, id: \.self) { category in
-                                Button(action: {
-                                    selectedCategory = category
-                                }) {
-                                    Text(category.displayName)
-                                        .font(.system(size: 18, weight: .bold))
-                                        .foregroundColor(selectedCategory == category ? .white : .gray)
-                                        .frame(width: 66, height: 36)
-                                        .background(selectedCategory == category ? Color.blue : Color(.systemGray5))
-                                        .cornerRadius(16)
-                                        .shadow(color: selectedCategory == category ? Color.blue.opacity(0.1) : .clear, radius: 2, y: 2)
+                    HStack(spacing: 16) {
+                        ScrollView(.horizontal, showsIndicators: false) {
+                            HStack() {
+                                ForEach(categories, id: \.self) { category in
+                                    Button(action: {
+                                        selectedCategory = category
+                                    }) {
+                                        Text(category.displayName)
+                                            .font(.system(size: 18, weight: .bold))
+                                            .foregroundColor(selectedCategory == category ? .white : .gray)
+                                            .frame(width: 66, height: 36)
+                                            .background(selectedCategory == category ? Color.mainws : Color(.systemGray5))
+                                            .cornerRadius(16)
+                                            .shadow(color: selectedCategory == category ? Color.blue.opacity(0.1) : .clear, radius: 2, y: 2)
+                                    }
                                 }
-                            }
-                            
-                            Menu {
-                                Button("최신순", action: {})
-                                Button("조회순", action: {})
-                            } label: {
-                                HStack {
-                                    Text("정렬 기준")
-                                        .font(.system(size: 16))
-                                    Image(systemName: "chevron.down")
-                                }
-                                .padding(.horizontal, 10)
-                                .padding(.vertical, 6)
-                                .background(Color.white)
-                                .cornerRadius(12)
-                                .shadow(color: .black.opacity(0.07), radius: 1, y: 1)
                             }
                         }
-                        .padding(.leading, 20)
-                        .padding(.vertical, 8)
+                        
+                        Menu {
+                            Button("최신순", action: {})
+                            Button("조회순", action: {})
+                        } label: {
+                            HStack {
+                                Text("정렬 기준")
+                                    .font(.system(size: 16))
+                                    .foregroundStyle(Color.mainws)
+                                
+                                Image(systemName: "chevron.down")
+                                    .foregroundColor(.mainws)
+                            }
+                            .padding(.horizontal, 10)
+                            .padding(.vertical, 6)
+                            .background(Color.white)
+                            .cornerRadius(12)
+                            .shadow(color: .black.opacity(0.07), radius: 1, y: 1)
+                        }
                     }
+                    .padding(.vertical, 8)
+                    .padding(.horizontal, 20)
                     
                     // 게시물 목록
                     ScrollView {
@@ -120,6 +125,7 @@ struct QuestionView: View {
                             }
                         }
                         .padding(.top, 8)
+                        .padding(.horizontal, 20)
                     }
                     
                     Spacer()
@@ -191,7 +197,7 @@ struct QuestionCard: View {
                         .foregroundColor(.white)
                         .padding(.horizontal, 10)
                         .padding(.vertical, 2)
-                        .background(Color.blue)
+                        .background(Color.mainws)
                         .cornerRadius(14)
                 }
                 Spacer()


### PR DESCRIPTION
## 📄 작업 내용
- 테스트플라이트 배포 전 디자인 색 통일 및 UI 잘리는 부분 수정했습니다.

<img width="250" alt="IMG_7914" src="https://github.com/user-attachments/assets/8b6aeb2a-1941-427d-9156-7389ed961837" />
<img width="250" alt="IMG_7913" src="https://github.com/user-attachments/assets/8eeed6bc-3de8-4645-91c2-e93a2c9496bd" />

## 💻 주요 코드 설명
- 기존에 하드 코딩 되어있던 혹은 기본 제공 색을 사용하던 부분을 에셋에 추가되어있는 색으로 변경했습니다! 
- `.sub1Ws`, `.mainws` or `Color.mainws` 와 같이 적용하여 사용했습니다~

Closes #19 