### PR TITLE
[feat] OCR 및 문제 요약 기능 뷰 구현

### DIFF
--- a/worlds-fe-v20/Extensions/UIImage+Extension.swift
+++ b/worlds-fe-v20/Extensions/UIImage+Extension.swift
@@ -1,0 +1,26 @@
+//
+//  UIImage+Extension.swift
+//  worlds-fe-v20
+//
+//  Created by seohuibaek on 7/28/25.
+//
+
+import UIKit
+
+extension UIImage: Identifiable {
+    public var id: UUID { UUID() }
+}
+
+// UIImage의 방향을 보정하는 확장
+extension UIImage {
+    func fixedOrientation() -> UIImage {
+        if imageOrientation == .up {
+            return self
+        }
+        UIGraphicsBeginImageContextWithOptions(size, false, scale)
+        draw(in: CGRect(origin: .zero, size: size))
+        let normalizedImage = UIGraphicsGetImageFromCurrentImageContext()!
+        UIGraphicsEndImageContext()
+        return normalizedImage
+    }
+}

--- a/worlds-fe-v20/Models/OCR.swift
+++ b/worlds-fe-v20/Models/OCR.swift
@@ -1,0 +1,15 @@
+//
+//  OCR.swift
+//  worlds-fe-v20
+//
+//  Created by seohuibaek on 7/30/25.
+//
+
+import Foundation
+
+struct OCR: Codable {
+    let message: String
+    let statusCode: Int
+    let originalText: [String]
+    let translatedText: [String]
+}

--- a/worlds-fe-v20/Models/OCRSolution.swift
+++ b/worlds-fe-v20/Models/OCRSolution.swift
@@ -1,0 +1,16 @@
+//
+//  OCRSolution.swift
+//  worlds-fe-v20
+//
+//  Created by seohuibaek on 7/30/25.
+//
+
+import Foundation
+
+struct OCRSolution: Codable {
+    let message: String
+    let statusCode: Int
+    let keyConcept: String
+    let solution: String
+    let summary: String
+}

--- a/worlds-fe-v20/Services/UserAPIManager.swift
+++ b/worlds-fe-v20/Services/UserAPIManager.swift
@@ -416,7 +416,7 @@ class UserAPIManager {
             throw UserAPIError.invalidToken
         }
         
-        guard let endPoint = Bundle.main.object(forInfoDictionaryKey: "APIOCR") as? String else {
+        guard let endPoint = Bundle.main.object(forInfoDictionaryKey: "APIOCRURL") as? String else {
             throw UserAPIError.invalidEndPoint
         }
         
@@ -472,7 +472,7 @@ class UserAPIManager {
             throw UserAPIError.invalidToken
         }
         
-        guard let endPoint = Bundle.main.object(forInfoDictionaryKey: "APIOCRSolution") as? String else {
+        guard let endPoint = Bundle.main.object(forInfoDictionaryKey: "APIOCRSolutionURL") as? String else {
             throw UserAPIError.invalidEndPoint
         }
         

--- a/worlds-fe-v20/ViewModels/LoginViewModel.swift
+++ b/worlds-fe-v20/ViewModels/LoginViewModel.swift
@@ -10,7 +10,6 @@ import SwiftUI
 final class LoginViewModel: ObservableObject {
     @Published var email: String = ""
     @Published var password: String = ""
-    
     @Published var errorMessage: String?
     
     // 로그인 함수

--- a/worlds-fe-v20/ViewModels/OCRViewModel.swift
+++ b/worlds-fe-v20/ViewModels/OCRViewModel.swift
@@ -1,0 +1,102 @@
+//
+//  OCRViewModel.swift
+//  worlds-fe-v20
+//
+//  Created by seohuibaek on 7/30/25.
+//
+
+import SwiftUI
+
+final class OCRViewModel: ObservableObject {
+    @Published var originalText: [String] = []
+    @Published var translatedText: [String] = []
+    @Published var keyConcept: String = ""
+    @Published var solution: String = ""
+    @Published var summary: String = ""
+
+    @Published var errorMessage: String?
+    
+    // 로딩 상태 추가
+    @Published var isOCRLoading: Bool = false
+    @Published var isSummaryLoading: Bool = false
+    
+    // Summary 데이터 캐싱을 위한 플래그
+    private var hasSummaryData: Bool = false
+    
+    @MainActor
+    func fetchOCR(selectedImage: UIImage) async throws {
+        isOCRLoading = true
+        errorMessage = nil
+        
+        // 1. UIImage를 Data로 변환
+        guard let imageData = selectedImage.jpegData(compressionQuality: 0.8) else {
+            print("이미지를 Data로 변환 실패")
+            isOCRLoading = false
+            return
+        }
+        
+        do {
+            let result = try await UserAPIManager.shared.OCRTranslation(file: imageData)
+            print("OCR 정보: \(result)")
+            
+            // 서버 응답에서 텍스트 배열들을 가져와서 할당
+            self.originalText = result.originalText
+            self.translatedText = result.translatedText
+            self.errorMessage = nil
+            
+        } catch UserAPIError.serverError(let message) {
+            self.errorMessage = message
+            print("서버 에러: \(message)")
+            
+        } catch {
+            self.errorMessage = "로그인 실패: \(error.localizedDescription)"
+            print("기타 에러: \(errorMessage)")
+            
+        }
+        
+        isOCRLoading = false
+    }
+    
+    @MainActor
+    func fetchOCRSolution() async throws {
+        // 이미 데이터가 있으면 다시 가져오지 않음
+        if hasSummaryData {
+            return
+        }
+        
+        isSummaryLoading = true
+        errorMessage = nil
+        
+        do {
+            let result = try await UserAPIManager.shared.OCRSummary()
+            print("OCRSummary 정보: \(result)")
+
+            self.keyConcept = result.keyConcept
+            self.solution = result.solution
+            self.summary = result.summary
+            
+            // 데이터를 성공적으로 가져왔으므로 플래그 설정
+            self.hasSummaryData = true
+            self.errorMessage = nil
+            
+        } catch UserAPIError.serverError(let message) {
+            self.errorMessage = message
+            print("서버 에러: \(message)")
+            
+        } catch {
+            self.errorMessage = "로그인 실패: \(error.localizedDescription)"
+            print("기타 에러: \(errorMessage)")
+            
+        }
+        
+        isSummaryLoading = false
+    }
+    
+    // Summary 데이터 초기화 (새로운 OCR을 시작할 때 호출)
+    func resetSummaryData() {
+        hasSummaryData = false
+        keyConcept = ""
+        solution = ""
+        summary = ""
+    }
+}

--- a/worlds-fe-v20/ViewModels/OCRViewModel.swift
+++ b/worlds-fe-v20/ViewModels/OCRViewModel.swift
@@ -99,4 +99,24 @@ final class OCRViewModel: ObservableObject {
         solution = ""
         summary = ""
     }
+    
+    // 질문 작성
+    func createQuestion(title: String, content: String, category: String, images: [UIImage]? = nil) async throws {
+        let imageData = images?.compactMap { $0.jpegData(compressionQuality: 0.7) } ?? []
+        
+        do {
+            let result = try await APIService.shared.createQuestion(title: title, content: content, category: category, images: imageData)
+            print("OCRSummary 정보: \(result)")
+
+            self.errorMessage = nil
+            
+        } catch UserAPIError.serverError(let message) {
+            self.errorMessage = message
+            print("서버 에러: \(message)")
+            
+        } catch {
+            self.errorMessage = "로그인 실패: \(error.localizedDescription)"
+            print("기타 에러: \(errorMessage)")
+        }
+    }
 }

--- a/worlds-fe-v20/Views/CreateQuestionView.swift
+++ b/worlds-fe-v20/Views/CreateQuestionView.swift
@@ -19,6 +19,10 @@ struct CreateQuestionView: View {
     @State private var imagePickerSourceType: UIImagePickerController.SourceType = .photoLibrary
 
     @State private var selectedCategory: Category? = nil
+    
+    // 초기값 설정을 위한 파라미터
+    var initialImages: [UIImage] = []
+    var initialCategory: Category? = nil
 
     var onSubmit: (_ images: [UIImage], _ category: String) -> Void
 
@@ -179,6 +183,14 @@ struct CreateQuestionView: View {
                     CameraPickerView(selectedImages: $selectedImages)
                 } else {
                     ImagePickerView(selectedImages: $selectedImages)
+                }
+            }
+            .onAppear {
+                if !initialImages.isEmpty {
+                    selectedImages = initialImages
+                }
+                if let initialCategory = initialCategory {
+                    selectedCategory = initialCategory
                 }
             }
             .onDisappear {

--- a/worlds-fe-v20/Views/OCR/OCRCameraController.swift
+++ b/worlds-fe-v20/Views/OCR/OCRCameraController.swift
@@ -1,0 +1,246 @@
+//
+//  OCRCameraController.swift
+//  worlds-fe-v20
+//
+//  Created by soy on 7/22/25.
+//
+
+import Foundation
+import AVFoundation
+import PhotosUI
+import SwiftUI
+import UIKit
+
+// 카메라 촬영 결과를 전달하는 델리게이트 프로토콜
+protocol OCRCameraControllerDelegate: AnyObject {
+    func didCapturePhoto(_ image: UIImage?)
+}
+
+// 카메라 촬영 및 미리보기, 사진 캡처를 담당하는 UIViewController
+class OCRCameraController: UIViewController, AVCapturePhotoCaptureDelegate {
+    weak var delegate: OCRCameraControllerDelegate?
+    private let captureSession = AVCaptureSession()
+    private var photoOutput: AVCapturePhotoOutput?
+    private var currentInput: AVCaptureDeviceInput?
+    private var previewLayer: AVCaptureVideoPreviewLayer?
+    var cameraPosition: AVCaptureDevice.Position = .back
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .backgroundws
+        setupPreviewLayer()
+        configureCaptureSession(position: cameraPosition)
+    }
+
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        previewLayer?.frame = view.bounds
+    }
+
+    // 미리보기 레이어 설정
+    private func setupPreviewLayer() {
+        let previewLayer = AVCaptureVideoPreviewLayer(session: captureSession)
+        previewLayer.videoGravity = .resizeAspectFill
+        previewLayer.frame = view.bounds
+        view.layer.addSublayer(previewLayer)
+        self.previewLayer = previewLayer
+    }
+
+    // 카메라 권한 요청
+    func requestCameraPermission() {
+        switch AVCaptureDevice.authorizationStatus(for: .video) {
+        case .notDetermined:
+            AVCaptureDevice.requestAccess(for: .video) { [weak self] granted in
+                if granted {
+                    DispatchQueue.main.async {
+                        self?.captureSession.startRunning()
+                    }
+                }
+            }
+        case .authorized:
+            // 백그라운드에서 세션 시작
+            DispatchQueue.global(qos: .userInitiated).async {
+                self.captureSession.startRunning()
+            }
+        case .denied, .restricted:
+            print("카메라 권한이 거부되었습니다.")
+        @unknown default:
+            print("알 수 없는 권한 상태입니다.")
+        }
+    }
+
+    // 캡처 세션 구성 및 카메라 전환
+    func configureCaptureSession(position: AVCaptureDevice.Position) {
+        cameraPosition = position
+        captureSession.stopRunning() // beginConfiguration() 전에 중지
+        captureSession.beginConfiguration()
+        // 기존 입력 제거
+        if let currentInput = currentInput {
+            captureSession.removeInput(currentInput)
+        }
+        // 새 입력 추가
+        let discoverySession = AVCaptureDevice.DiscoverySession(
+            deviceTypes: [.builtInWideAngleCamera],
+            mediaType: .video,
+            position: position
+        )
+        guard let cameraDevice = discoverySession.devices.first else {
+            print("사용 가능한 카메라가 없습니다.")
+            captureSession.commitConfiguration()
+            return
+        }
+        do {
+            let deviceInput = try AVCaptureDeviceInput(device: cameraDevice)
+            if captureSession.canAddInput(deviceInput) {
+                captureSession.addInput(deviceInput)
+                currentInput = deviceInput
+            }
+        } catch {
+            print("카메라 설정 오류: \(error.localizedDescription)")
+        }
+        // 기존 출력 제거 및 새 출력 추가
+        if let photoOutput = photoOutput {
+            captureSession.removeOutput(photoOutput)
+        }
+        let newPhotoOutput = AVCapturePhotoOutput()
+        if captureSession.canAddOutput(newPhotoOutput) {
+            captureSession.addOutput(newPhotoOutput)
+            photoOutput = newPhotoOutput
+        }
+        captureSession.commitConfiguration()
+        
+        DispatchQueue.global(qos: .userInitiated).async {
+            self.captureSession.startRunning()
+        }
+    }
+
+    // 카메라 전환
+    func switchCamera() {
+        let newPosition: AVCaptureDevice.Position = (cameraPosition == .back) ? .front : .back
+        configureCaptureSession(position: newPosition)
+    }
+
+    // 사진 촬영
+    func capturePhoto() {
+        guard let photoOutput = photoOutput, captureSession.isRunning else {
+            print("photoOutput이 nil이거나 세션이 실행 중이 아님")
+            return
+        }
+        let settings = AVCapturePhotoSettings()
+        photoOutput.capturePhoto(with: settings, delegate: self)
+    }
+
+    // MARK: - AVCapturePhotoCaptureDelegate
+    // 사진 촬영 결과 콜백
+    func photoOutput(_ output: AVCapturePhotoOutput, didFinishProcessingPhoto photo: AVCapturePhoto, error: Error?) {
+        if let error = error {
+            print("사진 촬영 오류: \(error)")
+            delegate?.didCapturePhoto(nil)
+            return
+        }
+        guard let imageData = photo.fileDataRepresentation(), let image = UIImage(data: imageData) else {
+            print("이미지 데이터 변환 실패")
+            delegate?.didCapturePhoto(nil)
+            return
+        }
+        print("이미지 생성 성공: \(image.size)")
+        delegate?.didCapturePhoto(image)
+    }
+}
+
+// SwiftUI에서 카메라 컨트롤러를 사용할 수 있게 하는 래퍼
+struct CameraPreview: UIViewControllerRepresentable {
+    @Binding var cameraPosition: AVCaptureDevice.Position
+    @Binding var cameraController: OCRCameraController?
+    var onPhotoCaptured: (UIImage?) -> Void
+    
+    func makeUIViewController(context: Context) -> OCRCameraController {
+        let controller = OCRCameraController()
+        controller.delegate = context.coordinator
+        controller.configureCaptureSession(position: cameraPosition)
+        cameraController = controller
+        return controller
+    }
+    
+    func updateUIViewController(_ uiViewController: OCRCameraController, context: Context) {
+        // 카메라 전환
+        if uiViewController.cameraPosition != cameraPosition {
+            uiViewController.configureCaptureSession(position: cameraPosition)
+        }
+    }
+    
+    func makeCoordinator() -> Coordinator {
+        Coordinator(self)
+    }
+    
+    // Coordinator: 델리게이트 콜백을 SwiftUI로 전달
+    class Coordinator: NSObject, OCRCameraControllerDelegate {
+        let parent: CameraPreview
+        init(_ parent: CameraPreview) {
+            self.parent = parent
+        }
+        func didCapturePhoto(_ image: UIImage?) {
+            parent.onPhotoCaptured(image)
+        }
+    }
+    
+    // 카메라 권한 요청
+    func requestCameraPermission(_ controller: OCRCameraController) {
+        controller.requestCameraPermission()
+    }
+    // 사진 촬영
+    func capturePhoto(_ controller: OCRCameraController) {
+        controller.capturePhoto()
+    }
+}
+
+// 앨범 선택을 위한 ImagePicker
+struct ImagePreview: UIViewControllerRepresentable {
+    @Binding var selectedImage: UIImage?
+    @Environment(\.presentationMode) var presentationMode
+    
+    func makeUIViewController(context: Context) -> PHPickerViewController {
+        var config = PHPickerConfiguration()
+        config.filter = .images
+        config.selectionLimit = 1  // OCR용 단일 이미지
+        
+        let picker = PHPickerViewController(configuration: config)
+        picker.delegate = context.coordinator
+        return picker
+    }
+    
+    func updateUIViewController(_ uiViewController: PHPickerViewController, context: Context) {}
+    
+    func makeCoordinator() -> Coordinator {
+        Coordinator(self)
+    }
+    
+    class Coordinator: NSObject, PHPickerViewControllerDelegate {
+        let parent: ImagePreview
+        
+        init(_ parent: ImagePreview) {
+            self.parent = parent
+        }
+        
+        func picker(_ picker: PHPickerViewController, didFinishPicking results: [PHPickerResult]) {
+            picker.dismiss(animated: true)
+            
+            guard let provider = results.first?.itemProvider else {
+                // 사용자가 취소한 경우
+                return
+            }
+            
+            if provider.canLoadObject(ofClass: UIImage.self) {
+                provider.loadObject(ofClass: UIImage.self) { [weak self] image, error in
+                    DispatchQueue.main.async {
+                        if let error = error {
+                            print("이미지 로딩 에러: \(error)")
+                            return
+                        }
+                        self?.parent.selectedImage = image as? UIImage
+                    }
+                }
+            }
+        }
+    }
+}

--- a/worlds-fe-v20/Views/OCR/OCRCameraView.swift
+++ b/worlds-fe-v20/Views/OCR/OCRCameraView.swift
@@ -30,7 +30,6 @@ struct OCRCameraView: View {
     var body: some View {
         NavigationStack {
             ZStack {
-                // 카메라 미리보기 뷰
                 CameraPreview(
                     cameraPosition: $cameraPosition,
                     cameraController: $cameraController,
@@ -41,7 +40,9 @@ struct OCRCameraView: View {
                         }
                     }
                 )
-                .ignoresSafeArea()
+                .cornerRadius(32)
+                .padding(.horizontal)
+                .padding(.top, 10)
                 
                 VStack {
                     

--- a/worlds-fe-v20/Views/OCR/OCRCameraView.swift
+++ b/worlds-fe-v20/Views/OCR/OCRCameraView.swift
@@ -1,0 +1,150 @@
+//
+//  OCRCameraView.swift
+//  worlds-fe-v20
+//
+//  Created by soy on 7/22/25.
+//
+
+import SwiftUI
+import AVFoundation
+import UIKit
+
+// OCR 카메라 뷰: 카메라 미리보기, 촬영, 사진 선택, 크롭, 결과 뷰까지 전체 흐름을 담당
+struct OCRCameraView: View {
+    // 카메라 방향(전/후면)
+    @State private var cameraPosition: AVCaptureDevice.Position = .back
+    // 사진 라이브러리 표시 여부
+    @State private var showingPhotoLibrary = false
+    // 선택된 원본 이미지
+    @State private var selectedImage: UIImage? = nil
+    // 크롭된 이미지
+    @State private var croppedImage: UIImage? = nil
+    // 결과 뷰 표시 여부
+    @State private var showingResultView = false
+    // 카메라 컨트롤러 인스턴스
+    @State private var cameraController: OCRCameraController? = nil
+    
+    // 공유 OCRViewModel 인스턴스
+    @StateObject private var ocrViewModel = OCRViewModel()
+    
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                // 카메라 미리보기 뷰
+                CameraPreview(
+                    cameraPosition: $cameraPosition,
+                    cameraController: $cameraController,
+                    onPhotoCaptured: { image in
+                        print("onPhotoCaptured 호출, image: \(String(describing: image))")
+                        DispatchQueue.main.async {
+                            selectedImage = image
+                        }
+                    }
+                )
+                .ignoresSafeArea()
+                
+                VStack {
+                    
+                    Spacer()
+
+                    HStack {
+                        Spacer()
+                        
+                        Button {
+                            showingPhotoLibrary = true
+                        } label: {
+                            Image(systemName: "photo.on.rectangle")
+                                .resizable()
+                                .scaledToFit()
+                                .frame(width: 30, height: 30)
+                                .foregroundColor(.mainws)
+                                .padding()
+                                .background(.ultraThinMaterial)
+                                .clipShape(Circle())
+                        }
+                        
+                        Spacer()
+                        
+                        // 사진 촬영 버튼
+                        Button {
+                            print("촬영 버튼 클릭됨")
+                            cameraController?.capturePhoto()
+                        } label: {
+                            Circle()
+                                .fill(.white)
+                                .frame(width: 80, height: 80)
+                                .overlay(
+                                    Circle()
+                                        .stroke(.mainws, lineWidth: 4)
+                                        .frame(width: 70, height: 70)
+                                )
+                        }
+                        
+                        Spacer()
+                        
+                        // 카메라 전환 버튼
+                        Button {
+                            cameraPosition = (cameraPosition == .back) ? .front : .back
+                        } label: {
+                            Image(systemName: "arrow.triangle.2.circlepath.camera")
+                                .resizable()
+                                .scaledToFit()
+                                .frame(width: 30, height: 30)
+                                .foregroundColor(.mainws)
+                                .padding()
+                                .background(.ultraThinMaterial)
+                                .clipShape(Circle())
+                        }
+                        
+                        Spacer()
+                    }
+                }
+                .padding()
+            }
+            .navigationTitle("OCR")
+            .navigationBarTitleDisplayMode(.inline)
+            .navigationBarBackButtonHidden(true)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button {
+                        // dismiss()
+                    } label: {
+                        Image(systemName: "chevron.left")
+                            .foregroundColor(.black)
+                            .font(.system(size: 18, weight: .semibold))
+                    }
+                }
+            }
+            // 사진 라이브러리에서 이미지 선택 시 표시되는 시트
+            .sheet(isPresented: $showingPhotoLibrary) {
+                ImagePreview(selectedImage: $selectedImage)
+            }
+            // 이미지 선택 시 크롭 뷰로 네비게이션
+            .navigationDestination(isPresented: Binding(
+                get: { selectedImage != nil },
+                set: { if !$0 { selectedImage = nil } }
+            )) {
+                if let image = selectedImage {
+                    OCRImageResizingView(originalImage: image) { cropped in
+                        croppedImage = cropped
+                        selectedImage = nil
+                        showingResultView = true
+                        // 새로운 OCR 세션 시작 시 Summary 데이터 초기화
+                        ocrViewModel.resetSummaryData()
+                    }
+                }
+            }
+            // 크롭된 이미지 결과 뷰로 네비게이션
+            .navigationDestination(isPresented: $showingResultView) {
+                if let image = croppedImage {
+                    OCRResultView(selectedImage: image)
+                        .environmentObject(ocrViewModel)
+                }
+            }
+            // 뷰가 나타날 때 카메라 권한 요청
+            .onAppear {
+                cameraController?.requestCameraPermission()
+            }
+        }
+    }
+}

--- a/worlds-fe-v20/Views/OCR/OCRCameraView.swift
+++ b/worlds-fe-v20/Views/OCR/OCRCameraView.swift
@@ -111,7 +111,7 @@ struct OCRCameraView: View {
                         // dismiss()
                     } label: {
                         Image(systemName: "chevron.left")
-                            .foregroundColor(.black)
+                            .foregroundColor(.mainws)
                             .font(.system(size: 18, weight: .semibold))
                     }
                 }

--- a/worlds-fe-v20/Views/OCR/OCRImageResizingView.swift
+++ b/worlds-fe-v20/Views/OCR/OCRImageResizingView.swift
@@ -1,0 +1,310 @@
+//
+//  OCRImageResizingView.swift
+//  worlds-fe-v20
+//
+//  Created by soy on 7/22/25.
+//
+
+import SwiftUI
+
+// 이미지 크롭 뷰: 사용자가 이미지를 원하는 영역만큼 잘라낼 수 있는 뷰
+struct OCRImageResizingView: View {
+    @StateObject var viewModel = OCRViewModel()
+
+    // 원본 이미지
+    let originalImage: UIImage
+    // 크롭 완료 시 호출되는 콜백
+    var onCrop: (UIImage) -> Void
+    @Environment(\.dismiss) private var dismiss
+    // 크롭 영역(0~1 비율)
+    @State private var cropRect: CGRect = CGRect(x: 0.2, y: 0.2, width: 0.6, height: 0.6)
+    // 드래그 변화량 누적값
+    @State private var dragOffset: CGSize = .zero
+    // 현재 드래그 중인 코너
+    @State private var activeCorner: Corner? = nil
+    // 마지막 드래그 값(누적)
+    @State private var lastDragValue: CGSize = .zero
+    // 크롭 영역 최소 크기
+    let minWidth: CGFloat = 0.1
+    let minHeight: CGFloat = 0.1
+
+    // 크롭 사각형의 네 모서리 구분
+    enum Corner { case topLeft, topRight, bottomLeft, bottomRight, none }
+
+    var body: some View {
+        NavigationStack {
+            
+            VStack {
+                GeometryReader { geo in
+                    ZStack {
+                        // 원본 이미지 표시
+                        Image(uiImage: originalImage)
+                            .resizable()
+                            .scaledToFit()
+                            .frame(width: geo.size.width, height: geo.size.height)
+                            .clipped()
+                        // 크롭 사각형 표시
+                        Rectangle()
+                            .path(in: cropRectFor(geo: geo))
+                            .stroke(.sub1Ws, lineWidth: 2)
+                            .background(
+                                Rectangle()
+                                    .fill(Color.black.opacity(0.3))
+                                    .frame(width: cropRectFor(geo: geo).width, height: cropRectFor(geo: geo).height)
+                                    .position(x: cropRectFor(geo: geo).midX, y: cropRectFor(geo: geo).midY)
+                            )
+                        // 사각형 전체 이동 제스처
+                            .gesture(
+                                DragGesture()
+                                    .onChanged { value in
+                                        let dx = (value.translation.width - lastDragValue.width) / geo.size.width
+                                        let dy = (value.translation.height - lastDragValue.height) / geo.size.height
+                                        lastDragValue = value.translation
+                                        var newRect = cropRect
+                                        newRect.origin.x = min(max(0, cropRect.origin.x + dx), 1 - cropRect.size.width)
+                                        newRect.origin.y = min(max(0, cropRect.origin.y + dy), 1 - cropRect.size.height)
+                                        cropRect = newRect
+                                    }
+                                    .onEnded { _ in
+                                        lastDragValue = .zero
+                                    }
+                            )
+                        // 네 모서리(코너) 핸들
+                        cornerHandle(.topLeft, geo: geo)
+                        cornerHandle(.topRight, geo: geo)
+                        cornerHandle(.bottomLeft, geo: geo)
+                        cornerHandle(.bottomRight, geo: geo)
+                    }
+                }
+                .aspectRatio(originalImage.size, contentMode: .fit)
+                .padding()
+                
+                Button {
+                    if let cropped = cropImage() {
+                        onCrop(cropped)
+                    }
+                } label: {
+                    ZStack {
+                        RoundedRectangle(cornerRadius: 10)
+                            .fill(Color.mainws)
+                            .frame(height: 60)
+                            .shadow(color: .black.opacity(0.25), radius: 4, x: 4, y: 4)
+                        
+                        HStack {
+                            Image(systemName: "text.viewfinder")
+                            Text("OCR 실행")
+                        }
+                        .font(.system(size: 20, weight: .bold))
+                        .foregroundStyle(.white)
+                    }
+                }
+                .padding()
+            }
+            .navigationTitle("이미지 크롭")
+            .navigationBarTitleDisplayMode(.inline)
+            .navigationBarBackButtonHidden(false)
+        }
+    }
+}
+
+
+extension OCRImageResizingView {
+    // cropRect를 실제 뷰 좌표계로 변환
+    private func cropRectFor(geo: GeometryProxy) -> CGRect {
+        CGRect(
+            x: cropRect.origin.x * geo.size.width,
+            y: cropRect.origin.y * geo.size.height,
+            width: cropRect.size.width * geo.size.width,
+            height: cropRect.size.height * geo.size.height
+        )
+    }
+
+    // 코너 핸들(모서리 원) 뷰
+    @ViewBuilder
+    private func cornerHandle(_ corner: Corner, geo: GeometryProxy) -> some View {
+        let rect = cropRectFor(geo: geo)
+        let size: CGFloat = 24
+        let pos: CGPoint = {
+            switch corner {
+            case .topLeft: return rect.origin
+            case .topRight: return CGPoint(x: rect.maxX, y: rect.minY)
+            case .bottomLeft: return CGPoint(x: rect.minX, y: rect.maxY)
+            case .bottomRight: return CGPoint(x: rect.maxX, y: rect.maxY)
+            case .none: return .zero
+            }
+        }()
+        Circle()
+            .fill(.mainws)
+            .frame(width: size, height: size)
+            .position(pos)
+            // 코너 드래그 제스처
+            .gesture(
+                DragGesture()
+                    .onChanged { value in
+                        let dx = (value.translation.width - lastDragValue.width) / geo.size.width
+                        let dy = (value.translation.height - lastDragValue.height) / geo.size.height
+                        lastDragValue = value.translation
+                        var newRect = cropRect
+                        let minDragThreshold: CGFloat = 0.003
+                        if abs(dx) < minDragThreshold && abs(dy) < minDragThreshold {
+                            return
+                        }
+                        let isDiagonal = abs(dx) > minDragThreshold && abs(dy) > minDragThreshold
+                        switch corner {
+                        case .topLeft:
+                            if isDiagonal {
+                                let delta = abs(dx) > abs(dy) ? dx : dy
+                                let newX = max(0, cropRect.origin.x + delta)
+                                let newY = max(0, cropRect.origin.y + delta)
+                                let maxX = cropRect.origin.x + cropRect.size.width - minWidth
+                                let maxY = cropRect.origin.y + cropRect.size.height - minHeight
+                                let finalX = min(newX, maxX)
+                                let finalY = min(newY, maxY)
+                                let appliedDeltaX = finalX - cropRect.origin.x
+                                let appliedDeltaY = finalY - cropRect.origin.y
+                                let appliedDelta = min(appliedDeltaX, appliedDeltaY)
+                                newRect.origin.x += appliedDelta
+                                newRect.origin.y += appliedDelta
+                                newRect.size.width -= appliedDelta
+                                newRect.size.height -= appliedDelta
+                            } else {
+                                if abs(dx) > minDragThreshold {
+                                    let newX = max(0, cropRect.origin.x + dx)
+                                    let maxX = cropRect.origin.x + cropRect.size.width - minWidth
+                                    let finalX = min(newX, maxX)
+                                    let appliedDelta = finalX - cropRect.origin.x
+                                    newRect.origin.x += appliedDelta
+                                    newRect.size.width -= appliedDelta
+                                }
+                                if abs(dy) > minDragThreshold {
+                                    let newY = max(0, cropRect.origin.y + dy)
+                                    let maxY = cropRect.origin.y + cropRect.size.height - minHeight
+                                    let finalY = min(newY, maxY)
+                                    let appliedDelta = finalY - cropRect.origin.y
+                                    newRect.origin.y += appliedDelta
+                                    newRect.size.height -= appliedDelta
+                                }
+                            }
+                        case .topRight:
+                            if isDiagonal {
+                                let delta = abs(dx) > abs(dy) ? -dx : dy
+                                let newMaxX = min(1, cropRect.origin.x + cropRect.size.width - delta)
+                                let newY = max(0, cropRect.origin.y + delta)
+                                let minX = cropRect.origin.x + minWidth
+                                let maxY = cropRect.origin.y + cropRect.size.height - minHeight
+                                let finalMaxX = max(newMaxX, minX)
+                                let finalY = min(newY, maxY)
+                                let appliedDeltaX = (cropRect.origin.x + cropRect.size.width) - finalMaxX
+                                let appliedDeltaY = cropRect.origin.y - finalY
+                                let appliedDelta = min(appliedDeltaX, appliedDeltaY)
+                                newRect.size.width -= appliedDelta
+                                newRect.origin.y += appliedDelta
+                                newRect.size.height -= appliedDelta
+                            } else {
+                                if abs(dx) > minDragThreshold {
+                                    let newMaxX = min(1, cropRect.origin.x + cropRect.size.width - dx)
+                                    let minX = cropRect.origin.x + minWidth
+                                    let finalMaxX = max(newMaxX, minX)
+                                    let appliedDelta = (cropRect.origin.x + cropRect.size.width) - finalMaxX
+                                    newRect.size.width -= appliedDelta
+                                }
+                                if abs(dy) > minDragThreshold {
+                                    let newY = max(0, cropRect.origin.y + dy)
+                                    let maxY = cropRect.origin.y + cropRect.size.height - minHeight
+                                    let finalY = min(newY, maxY)
+                                    let appliedDelta = finalY - cropRect.origin.y
+                                    newRect.origin.y += appliedDelta
+                                    newRect.size.height -= appliedDelta
+                                }
+                            }
+                        case .bottomLeft:
+                            if isDiagonal {
+                                let delta = abs(dx) > abs(dy) ? dx : -dy
+                                let newX = max(0, cropRect.origin.x + delta)
+                                let newMaxY = min(1, cropRect.origin.y + cropRect.size.height - delta)
+                                let maxX = cropRect.origin.x + cropRect.size.width - minWidth
+                                let minY = cropRect.origin.y + minHeight
+                                let finalX = min(newX, maxX)
+                                let finalMaxY = max(newMaxY, minY)
+                                let appliedDeltaX = cropRect.origin.x - finalX
+                                let appliedDeltaY = (cropRect.origin.y + cropRect.size.height) - finalMaxY
+                                let appliedDelta = min(appliedDeltaX, appliedDeltaY)
+                                newRect.origin.x += appliedDelta
+                                newRect.size.width -= appliedDelta
+                                newRect.size.height -= appliedDelta
+                            } else {
+                                if abs(dx) > minDragThreshold {
+                                    let newX = max(0, cropRect.origin.x + dx)
+                                    let maxX = cropRect.origin.x + cropRect.size.width - minWidth
+                                    let finalX = min(newX, maxX)
+                                    let appliedDelta = finalX - cropRect.origin.x
+                                    newRect.origin.x += appliedDelta
+                                    newRect.size.width -= appliedDelta
+                                }
+                                if abs(dy) > minDragThreshold {
+                                    let newMaxY = min(1, cropRect.origin.y + cropRect.size.height - dy)
+                                    let minY = cropRect.origin.y + minHeight
+                                    let finalMaxY = max(newMaxY, minY)
+                                    let appliedDelta = (cropRect.origin.y + cropRect.size.height) - finalMaxY
+                                    newRect.size.height -= appliedDelta
+                                }
+                            }
+                        case .bottomRight:
+                            if isDiagonal {
+                                let delta = abs(dx) > abs(dy) ? dx : dy
+                                let newMaxX = min(1, cropRect.origin.x + cropRect.size.width + delta)
+                                let newMaxY = min(1, cropRect.origin.y + cropRect.size.height + delta)
+                                let minX = cropRect.origin.x + minWidth
+                                let minY = cropRect.origin.y + minHeight
+                                let finalMaxX = max(newMaxX, minX)
+                                let finalMaxY = max(newMaxY, minY)
+                                let appliedDeltaX = finalMaxX - (cropRect.origin.x + cropRect.size.width)
+                                let appliedDeltaY = finalMaxY - (cropRect.origin.y + cropRect.size.height)
+                                let appliedDelta = min(appliedDeltaX, appliedDeltaY)
+                                newRect.size.width += appliedDelta
+                                newRect.size.height += appliedDelta
+                            } else {
+                                if abs(dx) > minDragThreshold {
+                                    let newMaxX = min(1, cropRect.origin.x + cropRect.size.width + dx)
+                                    let minX = cropRect.origin.x + minWidth
+                                    let finalMaxX = max(newMaxX, minX)
+                                    let appliedDelta = finalMaxX - (cropRect.origin.x + cropRect.size.width)
+                                    newRect.size.width += appliedDelta
+                                }
+                                if abs(dy) > minDragThreshold {
+                                    let newMaxY = min(1, cropRect.origin.y + cropRect.size.height + dy)
+                                    let minY = cropRect.origin.y + minHeight
+                                    let finalMaxY = max(newMaxY, minY)
+                                    let appliedDelta = finalMaxY - (cropRect.origin.y + cropRect.size.height)
+                                    newRect.size.height += appliedDelta
+                                }
+                            }
+                        case .none: break
+                        }
+                        newRect.size.width = max(newRect.size.width, minWidth)
+                        newRect.size.height = max(newRect.size.height, minHeight)
+                        newRect.origin.x = min(max(0, newRect.origin.x), 1 - newRect.size.width)
+                        newRect.origin.y = min(max(0, newRect.origin.y), 1 - newRect.size.height)
+                        cropRect = newRect
+                    }
+                    .onEnded { _ in
+                        activeCorner = nil
+                        lastDragValue = .zero
+                    }
+            )
+    }
+
+    // 실제 이미지 크롭
+    private func cropImage() -> UIImage? {
+        let fixedImage = originalImage.fixedOrientation()
+        let imageSize = fixedImage.size
+        let crop = CGRect(
+            x: cropRect.origin.x * imageSize.width,
+            y: cropRect.origin.y * imageSize.height,
+            width: cropRect.size.width * imageSize.width,
+            height: cropRect.size.height * imageSize.height
+        )
+        guard let cgImage = fixedImage.cgImage?.cropping(to: crop) else { return nil }
+        return UIImage(cgImage: cgImage)
+    }
+}

--- a/worlds-fe-v20/Views/OCR/OCRResultView.swift
+++ b/worlds-fe-v20/Views/OCR/OCRResultView.swift
@@ -1,0 +1,169 @@
+//
+//  OCRResultView.swift
+//  worlds-fe-v20
+//
+//  Created by soy on 7/22/25.
+//
+
+import SwiftUI
+import UIKit
+
+// OCR 결과 화면: 크롭된 이미지를 보여주고, OCR 결과 텍스트를 표시
+struct OCRResultView: View {
+    // 선택된(크롭된) 이미지
+    let selectedImage: UIImage
+    @State private var showingSummaryView = false
+
+    @Environment(\.dismiss) private var dismiss
+    
+    // 공유 OCRViewModel 사용
+    @EnvironmentObject private var viewModel: OCRViewModel
+    
+    var body: some View {
+        ZStack {
+            VStack(spacing: 20) {
+                HStack(spacing: 15) {
+                    Text("한국어")
+                        .font(.system(size: 16, weight: .semibold))
+                        .foregroundColor(.black)
+                        .frame(maxWidth: .infinity)
+                        .padding()
+                        .background(.sub2Ws)
+                        .cornerRadius(16)
+                    
+                    Image(systemName: "arrowshape.right.fill")
+                        .resizable()
+                        .scaledToFit()
+                        .frame(width: 30, height: 30)
+                        .foregroundColor(.sub2Ws)
+                        .padding()
+                    
+                    Text("영어")
+                        .font(.system(size: 16, weight: .semibold))
+                        .foregroundColor(.black)
+                        .frame(maxWidth: .infinity)
+                        .padding()
+                        .background(.sub2Ws)
+                        .cornerRadius(16)
+                }
+                
+                // 선택된 이미지 표시
+                Image(uiImage: selectedImage)
+                    .resizable()
+                    .scaledToFit()
+                    .frame(maxHeight: 300)
+                    .cornerRadius(12)
+                    .shadow(radius: 5)
+
+                if viewModel.isOCRLoading {
+                    // 로딩 중일 때 프로그레스 뷰 표시
+                    VStack(spacing: 16) {
+                        ProgressView()
+                            .scaleEffect(1.5)
+                            .progressViewStyle(CircularProgressViewStyle(tint: .mainws))
+                        
+                        Text("텍스트를 분석하고 있습니다...")
+                            .font(.system(size: 16, weight: .medium))
+                            .foregroundColor(.gray)
+                    }
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 40)
+                    .background(.backgroundws)
+                    .cornerRadius(12)
+                } else {
+                    // OCR 결과 표시
+                    ScrollView {
+                        VStack(alignment: .leading, spacing: 8) {
+                            ForEach(0..<viewModel.originalText.count, id: \.self) { index in
+                                VStack(alignment: .leading, spacing: 8) {
+                                    Text(viewModel.originalText[index])
+                                        .font(.body)
+                                        .foregroundColor(.black)
+                                    
+                                    Text(viewModel.translatedText[index])
+                                        .font(.body)
+                                        .foregroundColor(.mainws)
+                                    
+                                    Divider()
+                                }
+                                .padding(.vertical, 4)
+                            }
+                        }
+                        .padding()
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .background(.backgroundws)
+                    }
+                    .cornerRadius(8)
+                }
+                            
+                // 버튼들
+                HStack(spacing: 15) {
+                    Button {
+                        // performOCR()
+                        showingSummaryView = true
+                    } label: {
+                            Text("개념 보기")
+                            .font(.system(size: 16, weight: .semibold))
+                            .foregroundStyle(.white)
+                            .frame(maxWidth: .infinity)
+                            .padding()
+                            .background(.mainws)
+                            .cornerRadius(16)
+                    }
+                    .disabled(viewModel.isOCRLoading)
+                    
+                    Button {
+                        dismiss()
+                    } label: {
+                        Text("질문하기")
+                            .font(.system(size: 16, weight: .semibold))
+                            .foregroundColor(.gray)
+                            .frame(maxWidth: .infinity)
+                            .padding()
+                            .background(.backgroundws)
+                            .cornerRadius(16)
+                    }
+                    .disabled(viewModel.isOCRLoading)
+                    
+                    Button {
+                        dismiss()
+                    } label: {
+                        Text("재촬영")
+                            .font(.system(size: 16, weight: .semibold))
+                            .foregroundColor(.gray)
+                            .frame(maxWidth: .infinity)
+                            .padding()
+                            .background(.backgroundws)
+                            .cornerRadius(16)
+                    }
+                    .disabled(viewModel.isOCRLoading)
+                }
+            }
+            .padding()
+            .navigationTitle("OCR 결과")
+            .navigationBarTitleDisplayMode(.inline)
+            .navigationBarBackButtonHidden(false)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button("닫기") {
+                        dismiss()
+                    }
+                }
+            }
+            .sheet(isPresented: $showingSummaryView) {
+                OCRSummaryView()
+                    .environmentObject(viewModel)
+            }
+            .onAppear {
+                Task {
+                    try await viewModel.fetchOCR(selectedImage: selectedImage)
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    OCRResultView(selectedImage: UIImage(systemName: "photo") ?? UIImage())
+        .environmentObject(OCRViewModel())
+}

--- a/worlds-fe-v20/Views/OCR/OCRResultView.swift
+++ b/worlds-fe-v20/Views/OCR/OCRResultView.swift
@@ -14,7 +14,8 @@ struct OCRResultView: View {
     let selectedImage: UIImage
     @State private var showingSummaryView = false
 
-    @Environment(\.dismiss) private var dismiss
+    @EnvironmentObject var appState: AppState
+    @Environment(\.dismiss) var dismiss
     
     // 공유 OCRViewModel 사용
     @EnvironmentObject private var viewModel: OCRViewModel
@@ -142,11 +143,25 @@ struct OCRResultView: View {
             .padding()
             .navigationTitle("OCR 결과")
             .navigationBarTitleDisplayMode(.inline)
-            .navigationBarBackButtonHidden(false)
+            .navigationBarBackButtonHidden(true)
             .toolbar {
-                ToolbarItem(placement: .navigationBarTrailing) {
-                    Button("닫기") {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button {
                         dismiss()
+                    } label: {
+                        Image(systemName: "chevron.left")
+                            .foregroundColor(.mainws)
+                            .font(.system(size: 18, weight: .semibold))
+                    }
+                }
+                
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button {
+                        appState.flow = .main
+                    } label: {
+                        Image(systemName: "house")
+                            .foregroundColor(.mainws)
+                            .font(.system(size: 18, weight: .semibold))
                     }
                 }
             }

--- a/worlds-fe-v20/Views/OCR/OCRSummaryView.swift
+++ b/worlds-fe-v20/Views/OCR/OCRSummaryView.swift
@@ -1,0 +1,85 @@
+//
+//  OCRSummaryView.swift
+//  worlds-fe-v20
+//
+//  Created by seohuibaek on 7/30/25.
+//
+
+import SwiftUI
+
+struct OCRSummaryView: View {
+    @EnvironmentObject private var viewModel: OCRViewModel
+
+    var body: some View {
+        ZStack {
+            Color(.backgroundws)
+                .ignoresSafeArea()
+            
+            if viewModel.isSummaryLoading {
+                // 로딩 중일 때 프로그레스 뷰 표시
+                VStack(spacing: 20) {
+                    ProgressView()
+                        .scaleEffect(1.5)
+                        .progressViewStyle(CircularProgressViewStyle(tint: .mainws))
+                    
+                    Text("개념을 분석하고 있습니다...")
+                        .font(.system(size: 18, weight: .medium))
+                        .foregroundColor(.gray)
+                }
+            } else {
+                ScrollView() {
+                    VStack(alignment: .leading) {
+                        Text("핵심 개념")
+                            .font(.system(size: 20, weight: .semibold))
+                            .foregroundStyle(Color.black)
+                            .padding(.top, 20)
+                        
+                        
+                        Text(viewModel.keyConcept)
+                            .padding()
+                            .background(
+                                RoundedRectangle(cornerRadius: 16)
+                                    .fill(.white)
+                            )
+                            .padding(.bottom, 32)
+                        
+                        Text("문제 요약")
+                            .font(.system(size: 20, weight: .semibold))
+                            .foregroundStyle(Color.black)
+                        
+                        Text(viewModel.summary)
+                            .padding()
+                            .background(
+                                RoundedRectangle(cornerRadius: 16)
+                                    .fill(.white)
+                            )
+                            .padding(.bottom, 32)
+                        
+                        Text("힌트")
+                            .font(.system(size: 20, weight: .semibold))
+                            .foregroundStyle(Color.black)
+                        
+                        Text(viewModel.solution)
+                            .padding()
+                            .background(
+                                RoundedRectangle(cornerRadius: 16)
+                                    .fill(.white)
+                            )
+                            .padding(.bottom, 32)
+                    }
+                    .padding()
+                }
+            }
+        }
+        .onAppear {
+            Task {
+                try await viewModel.fetchOCRSolution()
+            }
+        }
+    }
+}
+
+#Preview {
+    OCRSummaryView()
+        .environmentObject(OCRViewModel())
+}


### PR DESCRIPTION
## 📄 작업 내용
- OCR 기능 구현했습니다.
카메라 촬영, 이미지 선택 이후 사이즈 조정 -> OCR 결과 받아오는 부분 확인했습니다.

- 문제 요약 기능 구현
문제 요약 API연동을 통해 문제의 핵심 주제, 요약, 핵심 개념에 대한 결과 받아왔습니다,

- 이미지 바로 게시판 연동할 수 있도록 기능 구현
<img width="200" alt="IMG_7921" src="https://github.com/user-attachments/assets/ba68f11e-4f42-4f0e-9a31-2bf7fedb16de" />
<img width="200"  alt="IMG_7922" src="https://github.com/user-attachments/assets/6720381d-1b9f-4698-abf2-0ba7137d7e44" />
<br>
<img width="200"  alt="IMG_7923" src="https://github.com/user-attachments/assets/c6f3c34e-73a7-4032-9ad1-239ea3ad8b0c" />
<img width="200"   alt="IMG_7924" src="https://github.com/user-attachments/assets/f08e14c8-3558-4489-b16c-20c74b0c476c" />

## 💻 주요 코드 설명
`OCRCameraController.swift`
- 해당 파일에 커스텀 카메라 구현, 앨범에서 사진 선택 기능 구현했습니다.

`OCRCameraView` -> `OCRImageResizingView` -> `OCRResultView` -> `OCRSummaryView` 순으로
카메라 촬영 및 앨범 선택 -> 이미지 크기 조정 -> 결과 화면 -> 요약 및 핵심 개념 모달 순 입니다.

`OCRResultView.swift`에서 게시물을 바로 올릴 수 있도록 `CreateQuestionView.swift`에 연결하는 과정에서
카테고리는 학습으로 고정, 이미지도 넘겨야 했으므로 아래와 같이 `CreateQuestionView.swift`에 코드를 수정했습니다.
기존 기능은 그대로 유지하면서, OCR결과 화면에서 게시글을 올릴 수 있도록 코드 추가만 했습니다.

```swift
CreateQuestionView.swift

var initialImages: [UIImage] = []
var initialCategory: Category? = nil

    .onAppear {
        if !initialImages.isEmpty {
            selectedImages = initialImages
        }
        if let initialCategory = initialCategory {
            selectedCategory = initialCategory
        }
    }
```

## 💬 공유사항 to 리뷰어
- 기존에 `CameraPickerView`와 `ImagePickerView`가 구현되어 있다는 점을 인지하였으나, 우선은 커스텀 카메라 뷰를 사용하기 위해 `OCRCameraController`를 따로 구현하였습니다.
- 충돌이 우려되어 info.plist에 ocr 연관 API URL은 아직 등록해두지 않았습니다.