### PR TITLE
[feature] 게시판 번역기능 구글 api 사용 및 백엔드 연동

### DIFF
--- a/Endpoint.xcconfig
+++ b/Endpoint.xcconfig
@@ -1,0 +1,24 @@
+//
+//  Endpoint.xcconfig
+//  worlds-fe-v20
+//
+//  Created by seohuibaek on 7/20/25.
+//
+
+// Configuration settings file format documentation can be found at:
+// https://help.apple.com/xcode/#/dev745c5c974
+
+// API_BASE_URL = http:/$()/192.168.100.91:3000/
+API_BASE_URL = https:/$()/worldstudy.azurewebsites.net
+
+API_SIGNUP_URL = $(API_BASE_URL)/auth/signup
+API_LOGIN_URL = $(API_BASE_URL)/auth/signin
+API_LOGOUT_URL = $(API_BASE_URL)/auth/signout
+
+API_CHECK_EMAIL_URL = $(API_BASE_URL)/auth/check-email
+API_ACCESS_TOKEN_URL = $(API_BASE_URL)/auth/refresh
+API_USER_INFO_URL = $(API_BASE_URL)/auth/userinfo
+API_CHANGE_PASSWORD_URL = $(API_BASE_URL)/auth/change-password
+API_FIND_EMAIL_URL = $(API_BASE_URL)/auth/find-email
+
+SOCKET_URL = http:/$()/192.168.100.91:3000/

--- a/worlds-fe-v20/Endpoint.xcconfig
+++ b/worlds-fe-v20/Endpoint.xcconfig
@@ -1,0 +1,24 @@
+//
+//  Endpoint.xcconfig
+//  worlds-fe-v20
+//
+//  Created by seohuibaek on 7/20/25.
+//
+
+// Configuration settings file format documentation can be found at:
+// https://help.apple.com/xcode/#/dev745c5c974
+
+// API_BASE_URL = http:/$()/192.168.100.91:3000/
+API_BASE_URL = https:/$()/worldstudy.azurewebsites.net
+
+API_SIGNUP_URL = $(API_BASE_URL)/auth/signup
+API_LOGIN_URL = $(API_BASE_URL)/auth/signin
+API_LOGOUT_URL = $(API_BASE_URL)/auth/signout
+
+API_CHECK_EMAIL_URL = $(API_BASE_URL)/auth/check-email
+API_ACCESS_TOKEN_URL = $(API_BASE_URL)/auth/refresh
+API_USER_INFO_URL = $(API_BASE_URL)/auth/userinfo
+API_CHANGE_PASSWORD_URL = $(API_BASE_URL)/auth/change-password
+API_FIND_EMAIL_URL = $(API_BASE_URL)/auth/find-email
+
+SOCKET_URL = http:/$()/192.168.100.91:3000/

--- a/worlds-fe-v20/Services/APIService.swift
+++ b/worlds-fe-v20/Services/APIService.swift
@@ -10,329 +10,358 @@ import Alamofire
 import UIKit
 
 class APIService {
-    static let shared = APIService()
-    
-    enum APIError: Error {
-        case missingToken
-        case invalidEndPoint
-    }
-    
-    // baseURL은 Info.plist에서 가져옴
-    private var baseURL: String {
-        guard let url = Bundle.main.object(forInfoDictionaryKey: "APIBaseURL") as? String else {
-            fatalError("APIBaseURL is not set in Info.plist")
-        }
-            return url
-    }
-    
-    // JWT 토큰 가져오기
-    func getToken() -> String? {
-        UserDefaults.standard.string(forKey: "accessToken")
-    }
+static let shared = APIService()
 
-    //토큰이 필요한 API 호출을 위한 HTTP헤더 생성
-    private func getAuthHeaders() throws -> HTTPHeaders {
-        guard let token = getToken() else {
-            throw APIError.missingToken
-        }
-        return ["Authorization": "Bearer \(token)"]
-    }
+enum APIError: Error {
+    case missingToken
+    case invalidEndPoint
+}
 
-    //질문 목록 조회
-    func fetchQuestions() async throws -> [QuestionList] {
-        let headers = try getAuthHeaders()
-        
-        let response = try await AF.request("\(baseURL)/questions", headers: headers)
-            .serializingDecodable([QuestionList].self)
-            .value
-        
-        return response
+// baseURL은 Info.plist에서 가져옴
+private var baseURL: String {
+    guard let url = Bundle.main.object(forInfoDictionaryKey: "APIBaseURL") as? String else {
+        fatalError("APIBaseURL is not set in Info.plist")
     }
-    
-    //질문 상세
-    func fetchQuestionDetail(questionId: Int) async throws -> QuestionDetail {
-        let headers = try getAuthHeaders()
-        
-        let response = try await AF.request("\(baseURL)/questions/\(questionId)", headers: headers)
-            .serializingDecodable(QuestionDetail.self)
-            .value
-        
-        return response
+        return url
+}
+
+// JWT 토큰 가져오기
+func getToken() -> String? {
+    UserDefaults.standard.string(forKey: "accessToken")
+}
+
+//토큰이 필요한 API 호출을 위한 HTTP헤더 생성
+private func getAuthHeaders() throws -> HTTPHeaders {
+    guard let token = getToken() else {
+        throw APIError.missingToken
     }
+    return ["Authorization": "Bearer \(token)"]
+}
+
+//질문 목록 조회
+func fetchQuestions() async throws -> [QuestionList] {
+    let headers = try getAuthHeaders()
     
-    //질문 생성
-    func createQuestion(title: String, content: String, category: String, images: [Data]? = nil) async throws -> Bool {
-        let headers = try getAuthHeaders()
-        
-        // 이미지가 있으면 multipart/form-data 전송
-        if let imagesData = images, !imagesData.isEmpty {
+    let response = try await AF.request("\(baseURL)/questions", headers: headers)
+        .serializingDecodable([QuestionList].self)
+        .value
+    
+    return response
+}
+
+//질문 상세
+func fetchQuestionDetail(questionId: Int) async throws -> QuestionDetail {
+    let headers = try getAuthHeaders()
+    
+    let response = try await AF.request("\(baseURL)/questions/\(questionId)", headers: headers)
+        .serializingDecodable(QuestionDetail.self)
+        .value
+    
+    return response
+}
+
+//질문 생성
+func createQuestion(title: String, content: String, category: String, images: [Data]? = nil) async throws -> Bool {
+    let headers = try getAuthHeaders()
+    
+    // 이미지가 있으면 multipart/form-data 전송
+    if let imagesData = images, !imagesData.isEmpty {
 //            print("multipart 업로드 시작")
-            let url = "\(baseURL)/questions/with-image"
-            
-            return try await withCheckedThrowingContinuation { continuation in
-                AF.upload(
-                    multipartFormData: { multipartFormData in
-                        multipartFormData.append(title.data(using: .utf8)!, withName: "title")
-                        multipartFormData.append(content.data(using: .utf8)!, withName: "content")
-                        multipartFormData.append(category.data(using: .utf8)!, withName: "category")
-                        
-                        for (index, imageData) in imagesData.enumerated() {
-                            multipartFormData.append(imageData,
-                                                     withName: "images",
-                                                     fileName: "image\(index).jpg",
-                                                     mimeType: "image/jpeg")
-                        }
-                    },
-                    to: url,
-                    method: .post,
-                    headers: headers
-                )
-                .validate()
-                .response { response in
-                    switch response.result {
-                    case .success:
-                        continuation.resume(returning: true)
-                    case .failure(let error):
-                        continuation.resume(throwing: error)
+        let url = "\(baseURL)/questions/with-image"
+        
+        return try await withCheckedThrowingContinuation { continuation in
+            AF.upload(
+                multipartFormData: { multipartFormData in
+                    multipartFormData.append(title.data(using: .utf8)!, withName: "title")
+                    multipartFormData.append(content.data(using: .utf8)!, withName: "content")
+                    multipartFormData.append(category.data(using: .utf8)!, withName: "category")
+                    
+                    for (index, imageData) in imagesData.enumerated() {
+                        multipartFormData.append(imageData,
+                                                 withName: "images",
+                                                 fileName: "image\(index).jpg",
+                                                 mimeType: "image/jpeg")
                     }
+                },
+                to: url,
+                method: .post,
+                headers: headers
+            )
+            .validate()
+            .response { response in
+                switch response.result {
+                case .success:
+                    continuation.resume(returning: true)
+                case .failure(let error):
+                    continuation.resume(throwing: error)
                 }
             }
-        } else {
-            let url = "\(baseURL)/questions"
-            let params: [String: Any] = [
-                "title": title,
-                "content": content,
-                "category": category
-            ]
-            let response = try await AF.request(
-                url,
-                method: .post,
-                parameters: params,
-                encoding: JSONEncoding.default,
-                headers: headers )
-                .validate()
-                .serializingData()
-                .response
-            
-            return response.error == nil
         }
-    }
-    
-    
-    //질문 삭제
-    func deleteQuestion(questionId: Int) async throws -> Bool {
-        let headers = try getAuthHeaders()
-        
-        let response = try await AF.request("\(baseURL)/questions/\(questionId)", method: .delete,
-                                            headers: headers)
-            .validate()
-            .serializingData()
-            .response
-        
-        print("삭제 완료: \(response)")
-        return response.error == nil
-        
-    }
-    
-    //질문 신고
-    func reportQuestion(
-        questionId: Int,
-        reason: ReportReason,
-        etcReason: String? = nil
-    ) async throws -> Bool {
-        let headers = try getAuthHeaders()
-        var params: [String: Any] = [
-            "reason": reason.rawValue
+    } else {
+        let url = "\(baseURL)/questions"
+        let params: [String: Any] = [
+            "title": title,
+            "content": content,
+            "category": category
         ]
-        if let etc = etcReason, !etc.isEmpty {
-            params["etcReason"] = etc
-        }
-        
-        let response = try await AF.request(
-            "\(baseURL)/questions/\(questionId)/report",
-            method: .post,
-            parameters: params,
-            encoding: JSONEncoding.default,
-            headers: headers
-        )
-            .validate()
-            .serializingData()
-            .response
-        
-        print("신고 응답: \(response)")
-        return response.error == nil
-    }
-    
-    // 댓글, 대댓글 작성
-    func postComment(content: String, questionId: Int, parentId: Int? = nil) async throws -> Bool {
-        let headers = try getAuthHeaders()
-        var params: [String: Any] = ["content": content]
-        
-        let url: String
-        
-        if let parentId = parentId {
-            // 대댓글인 경우
-            url = "\(baseURL)/comment/\(parentId)/reply"
-        } else {
-            // 일반 댓글인 경우
-            url = "\(baseURL)/comment/question/\(questionId)"
-        }
-        
         let response = try await AF.request(
             url,
             method: .post,
             parameters: params,
             encoding: JSONEncoding.default,
-            headers: headers
-        )
-        .validate()
-        .serializingData()
-        .response
-        
-        return response.error == nil
-    }
-    
-    // 댓글 조회
-    func fetchComments(for questionId: Int) async throws -> [Comment] {
-        let headers = try getAuthHeaders()
-        
-        let response = try await AF.request(
-            "\(baseURL)/comment/question/\(questionId)",
-            headers: headers
-        )
-            .validate()
-            .serializingDecodable([Comment].self)
-            .value
-        
-        return response
-    }
-    
-    // 댓글 신고
-    func reportComment(commentId: Int, reason: String, etcReason: String? = nil, questionId: Int? = nil) async throws -> Bool {
-        let headers = try getAuthHeaders()
-        
-        var params: [String: Any] = [
-            "reason": reason
-        ]
-        
-        if let etcReason = etcReason {
-            params["etcReason"] = etcReason
-        }
-        
-        if let questionId = questionId {
-            params["questionId"] = questionId
-        }
-        
-        let response = try await AF.request(
-            "\(baseURL)/comment/\(commentId)/report",
-            method: .post,
-            parameters: params,
-            encoding: JSONEncoding.default,
-            headers: headers
-        )
+            headers: headers )
             .validate()
             .serializingData()
             .response
         
         return response.error == nil
     }
+}
     
-    // 댓글 삭제
-    func deleteComment(commentId: Int) async throws -> Bool {
-        let headers = try getAuthHeaders()
-        
-        let response = try await AF.request(
-            "\(baseURL)/comment/\(commentId)",
+    
+// 번역 요청
+func translateText(text: String, source: String = "ko", target: String, completion: @escaping (String?) -> Void) {
+    let url = "\(baseURL)/translate"
+    
+    let parameters: [String: Any] = [
+        "text": text,
+        "source": source,
+        "target": target
+    ]
+    
+    AF.request(
+        url,
+        method: .post,
+        parameters: parameters,
+        encoding: JSONEncoding.default
+    )
+    .validate()
+    .responseDecodable(of: [String: String].self) { response in
+        switch response.result {
+        case .success(let data):
+            completion(data["translated"])
+        case .failure(let error):
+            print("❌ 번역 실패: \(error.localizedDescription)")
+            completion(nil)
+        }
+    }
+}
+
+
+//질문 삭제
+func deleteQuestion(questionId: Int) async throws -> Bool {
+    let headers = try getAuthHeaders()
+    
+    let response = try await AF.request("\(baseURL)/questions/\(questionId)", method: .delete,
+                                        headers: headers)
+        .validate()
+        .serializingData()
+        .response
+    
+    print("삭제 완료: \(response)")
+    return response.error == nil
+    
+}
+
+//질문 신고
+func reportQuestion(
+    questionId: Int,
+    reason: ReportReason,
+    etcReason: String? = nil
+) async throws -> Bool {
+    let headers = try getAuthHeaders()
+    var params: [String: Any] = [
+        "reason": reason.rawValue
+    ]
+    if let etc = etcReason, !etc.isEmpty {
+        params["etcReason"] = etc
+    }
+    
+    let response = try await AF.request(
+        "\(baseURL)/questions/\(questionId)/report",
+        method: .post,
+        parameters: params,
+        encoding: JSONEncoding.default,
+        headers: headers
+    )
+        .validate()
+        .serializingData()
+        .response
+    
+    print("신고 응답: \(response)")
+    return response.error == nil
+}
+
+// 댓글, 대댓글 작성
+func postComment(content: String, questionId: Int, parentId: Int? = nil) async throws -> Bool {
+    let headers = try getAuthHeaders()
+    var params: [String: Any] = ["content": content]
+    
+    let url: String
+    
+    if let parentId = parentId {
+        // 대댓글인 경우
+        url = "\(baseURL)/comment/\(parentId)/reply"
+    } else {
+        // 일반 댓글인 경우
+        url = "\(baseURL)/comment/question/\(questionId)"
+    }
+    
+    let response = try await AF.request(
+        url,
+        method: .post,
+        parameters: params,
+        encoding: JSONEncoding.default,
+        headers: headers
+    )
+    .validate()
+    .serializingData()
+    .response
+    
+    return response.error == nil
+}
+
+// 댓글 조회
+func fetchComments(for questionId: Int) async throws -> [Comment] {
+    let headers = try getAuthHeaders()
+    
+    let response = try await AF.request(
+        "\(baseURL)/comment/question/\(questionId)",
+        headers: headers
+    )
+        .validate()
+        .serializingDecodable([Comment].self)
+        .value
+    
+    return response
+}
+
+// 댓글 신고
+func reportComment(commentId: Int, reason: String, etcReason: String? = nil, questionId: Int? = nil) async throws -> Bool {
+    let headers = try getAuthHeaders()
+    
+    var params: [String: Any] = [
+        "reason": reason
+    ]
+    
+    if let etcReason = etcReason {
+        params["etcReason"] = etcReason
+    }
+    
+    if let questionId = questionId {
+        params["questionId"] = questionId
+    }
+    
+    let response = try await AF.request(
+        "\(baseURL)/comment/\(commentId)/report",
+        method: .post,
+        parameters: params,
+        encoding: JSONEncoding.default,
+        headers: headers
+    )
+        .validate()
+        .serializingData()
+        .response
+    
+    return response.error == nil
+}
+
+// 댓글 삭제
+func deleteComment(commentId: Int) async throws -> Bool {
+    let headers = try getAuthHeaders()
+    
+    let response = try await AF.request(
+        "\(baseURL)/comment/\(commentId)",
+        method: .delete,
+        headers: headers
+    )
+        .validate()
+        .serializingData()
+        .response
+    
+    return response.error == nil
+}
+
+// 댓글 좋아요 토글
+func toggleCommentLike(commentId: Int) async throws -> CommentLike {
+    let headers = try getAuthHeaders()
+  
+    // 먼저 POST 요청 (좋아요 시도)
+    let postResponse = try await AF.request(
+        "\(baseURL)/comment/like/\(commentId)",
+        method: .post,
+        headers: headers
+    )
+        .validate()
+        .serializingData()
+        .response
+    
+    if postResponse.error == nil {
+        // 좋아요 성공 → count 다시 조회
+        let count = try await fetchLikeCount(commentId: commentId)
+        return CommentLike(id: commentId, count: count, isLiked: true)
+    } else {
+        // 이미 좋아요한 상태일 경우 → DELETE로 취소 시도
+        let deleteResponse = try await AF.request(
+            "\(baseURL)/comment/like/\(commentId)",
             method: .delete,
             headers: headers
         )
             .validate()
             .serializingData()
             .response
-        
-        return response.error == nil
-    }
-    
-    // 댓글 좋아요 토글
-    func toggleCommentLike(commentId: Int) async throws -> CommentLike {
-        let headers = try getAuthHeaders()
       
-        // 먼저 POST 요청 (좋아요 시도)
-        let postResponse = try await AF.request(
-            "\(baseURL)/comment/like/\(commentId)",
-            method: .post,
-            headers: headers
-        )
-            .validate()
-            .serializingData()
-            .response
-        
-        if postResponse.error == nil {
-            // 좋아요 성공 → count 다시 조회
+        if deleteResponse.error == nil {
+            // 좋아요 취소 성공 → count 다시 조회
             let count = try await fetchLikeCount(commentId: commentId)
-            return CommentLike(id: commentId, count: count, isLiked: true)
+            return CommentLike(id: commentId, count: count, isLiked: false)
         } else {
-            // 이미 좋아요한 상태일 경우 → DELETE로 취소 시도
-            let deleteResponse = try await AF.request(
-                "\(baseURL)/comment/like/\(commentId)",
-                method: .delete,
-                headers: headers
-            )
-                .validate()
-                .serializingData()
-                .response
-          
-            if deleteResponse.error == nil {
-                // 좋아요 취소 성공 → count 다시 조회
-                let count = try await fetchLikeCount(commentId: commentId)
-                return CommentLike(id: commentId, count: count, isLiked: false)
-            } else {
-                // POST 실패 + DELETE 실패 → 에러 반환
-                throw deleteResponse.error!
-            }
+            // POST 실패 + DELETE 실패 → 에러 반환
+            throw deleteResponse.error!
         }
     }
-    
-    // 댓글 좋아요 수 + isLiked 여부 조회(백엔드를 따로따로 만들어서 둘을 합쳐 쓰기 위한 함수)
-    // 1. fetchLikeCount()를 호출해서 해당 댓글에 총 몇 개의 좋아요가 있는지 가져오고
-    // 2. fetchIsLiked()를 호출해서 내가 좋아요를 눌렀는지 서버에서 확인한 뒤
-    // 3. 그 정보를 바탕으로 CommentLike 구조체 생성해서 반환
-    func fetchCommentLike(commentId: Int) async throws -> CommentLike {
-        let headers = try getAuthHeaders()
-        let count = try await fetchLikeCount(commentId: commentId)
-        let isLiked = try await fetchIsLiked(commentId: commentId)
-        
-        return CommentLike(id: commentId, count: count, isLiked: isLiked)
-    }
-    
-    // 좋아요 수
-    func fetchLikeCount(commentId: Int) async throws -> Int {
-        let headers = try getAuthHeaders()
+}
 
-        let count = try await AF.request(
-            "\(baseURL)/comment/like/\(commentId)/count",
-            headers: headers
-        )
-            .validate()
-            .serializingDecodable(Int.self)
-            .value
-        
-        return count
-    }
+// 댓글 좋아요 수 + isLiked 여부 조회(백엔드를 따로따로 만들어서 둘을 합쳐 쓰기 위한 함수)
+// 1. fetchLikeCount()를 호출해서 해당 댓글에 총 몇 개의 좋아요가 있는지 가져오고
+// 2. fetchIsLiked()를 호출해서 내가 좋아요를 눌렀는지 서버에서 확인한 뒤
+// 3. 그 정보를 바탕으로 CommentLike 구조체 생성해서 반환
+func fetchCommentLike(commentId: Int) async throws -> CommentLike {
+    let headers = try getAuthHeaders()
+    let count = try await fetchLikeCount(commentId: commentId)
+    let isLiked = try await fetchIsLiked(commentId: commentId)
     
-    // 유저가 좋아요를 눌렀는지 여부
-    func fetchIsLiked(commentId: Int) async throws -> Bool {
-        let headers = try getAuthHeaders()
-      
-        let response = try await AF.request(
-            "\(baseURL)/comment/like/\(commentId)/isLiked",
-            method: .get,
-            headers: headers
-        )
-            .validate()
-            .serializingDecodable(Bool.self)
-            .value
-        
-        return response
-    }
+    return CommentLike(id: commentId, count: count, isLiked: isLiked)
+}
+
+// 좋아요 수
+func fetchLikeCount(commentId: Int) async throws -> Int {
+    let headers = try getAuthHeaders()
+
+    let count = try await AF.request(
+        "\(baseURL)/comment/like/\(commentId)/count",
+        headers: headers
+    )
+        .validate()
+        .serializingDecodable(Int.self)
+        .value
+    
+    return count
+}
+
+// 유저가 좋아요를 눌렀는지 여부
+func fetchIsLiked(commentId: Int) async throws -> Bool {
+    let headers = try getAuthHeaders()
+  
+    let response = try await AF.request(
+        "\(baseURL)/comment/like/\(commentId)/isLiked",
+        method: .get,
+        headers: headers
+    )
+        .validate()
+        .serializingDecodable(Bool.self)
+        .value
+    
+    return response
+}
 }

--- a/worlds-fe-v20/Views/QuestionDetailView.swift
+++ b/worlds-fe-v20/Views/QuestionDetailView.swift
@@ -24,6 +24,9 @@ struct QuestionDetailView: View {
     
     @FocusState private var isTextFieldFocused: Bool
     
+    @State private var translatedTitle: String?
+    @State private var translatedContent: String?
+    
     let reportReasons: [(label: String, value: ReportReason)] = [
         ("비속어", .offensive),
         ("음란", .sexual),
@@ -84,13 +87,13 @@ struct QuestionDetailView: View {
                         }
                         .padding(.horizontal)
                         
-                        Text(question.title)
+                        Text(translatedTitle ?? question.title)
                             .font(.title)
                             .fontWeight(.bold)
                             .padding(.top, 24)
                             .padding(.horizontal)
-                        
-                        Text(question.content)
+
+                        Text(translatedContent ?? question.content)
                             .font(.body)
                             .foregroundColor(.black)
                             .padding(.top, 18)
@@ -128,11 +131,33 @@ struct QuestionDetailView: View {
                             }
                         }
                         
-                        Button("번역하기") {}
-                            .font(.callout)
-                            .foregroundColor(.blue)
-                            .padding(.horizontal)
-                            .padding(.top, 14)
+                        Button("번역하기") {
+                            guard let question = questionDetail else { return }
+                            
+                            let targetLang = Locale.preferredLanguages.first?.components(separatedBy: "-").first ?? "en"
+                            
+                            if targetLang == "ko" {
+                                self.translatedTitle = question.title
+                                self.translatedContent = question.content
+                                return
+                            }
+                            
+                            APIService().translateText(text: question.title, target: targetLang) { translated in
+                                DispatchQueue.main.async {
+                                    self.translatedTitle = translated
+                                }
+                            }
+                            
+                            APIService().translateText(text: question.content, target: targetLang) { translated in
+                                DispatchQueue.main.async {
+                                    self.translatedContent = translated
+                                }
+                            }
+                        }
+                        .font(.callout)
+                        .foregroundColor(.blue)
+                        .padding(.horizontal)
+                        .padding(.top, 14)
                         
                         Color.gray.opacity(0.1)
                             .frame(height: 13)
@@ -243,7 +268,8 @@ struct QuestionDetailView: View {
                 Task {
                     try await viewModel.deleteQuestion(id: questionId)
                     await MainActor.run {
-                        dismiss()
+                        viewModel.questions.removeAll { $0.id == questionId }
+                        presentationMode.wrappedValue.dismiss()
                     }
                 }
             }


### PR DESCRIPTION
## 📄 작업 내용

- 게시글 상세화면에서 `번역하기` 버튼 누르면 제목과 내용을 기기 언어에 따라 자동 번역되도록 구현했습니다.
- 기존 Google API 직접 호출 방식 -> **서버 프록시 방식**으로 변경
   - NestJS 백엔드의 /translate API를 호출 -> 보안good
   
- 사용자 기기 설정 언어로 자동 번역 !!

<img width="250" height="470" alt="image" src="https://github.com/user-attachments/assets/bfd46842-466b-4eac-aa58-9a3ea7b9f19e" />

<img width="250" height="470" alt="image" src="https://github.com/user-attachments/assets/df0276d6-e474-434d-87fb-fe19f124f44b" />



## 💻 주요 코드 설명

1. 구글 번역 api 사용
https://console.cloud.google.com/marketplace/product/google/translate.googleapis.com

2. `QuestionDetailView.swift`
```swift
Button("번역하기") {
        guard let question = questionDetail else { return }

        func translateText(_ text: String, completion: @escaping (String?) -> Void) {
            let targetLang = Locale.preferredLanguages.first?.components(separatedBy: "-").first ?? "en"

            // 번역 언어가 원문 == 번역 x
            if targetLang == "ko" {
                completion(text)
                return
            }

            let apiKey = "-----"
            let url = URL(string: "https://translation.googleapis.com/language/translate/v2?key=\(apiKey)")!

            var request = URLRequest(url: url)
            request.httpMethod = "POST"
            request.setValue("application/json", forHTTPHeaderField: "Content-Type")

            let body: [String: Any] = [
                "q": text,
                "source": "ko",
                "target": targetLang,
                "format": "text"
            ]

            request.httpBody = try? JSONSerialization.data(withJSONObject: body)

            URLSession.shared.dataTask(with: request) { data, response, error in
                guard let data = data else {
                    print("❌ 번역 실패: \(error?.localizedDescription ?? "No data")")
                    completion(nil)
                    return
                }

                if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
                   let dataObj = json["data"] as? [String: Any],
                   let translations = dataObj["translations"] as? [[String: Any]],
                   let translatedText = translations.first?["translatedText"] as? String {
                    completion(translatedText)
                } else {
                    print("❌ 번역 파싱 실패")
                    completion(nil)
                }
            }.resume()
        }

        translateText(question.title) { translated in
            DispatchQueue.main.async {
                self.translatedTitle = translated
            }
        }

        translateText(question.content) { translated in
            DispatchQueue.main.async {
                self.translatedContent = translated
            }
        }
    }
```
-> 프론트에서 구글 api 호출 -> 백엔드에서 호출로 변경 

- `번역하기` 버튼 누르면 `APIService.translateText()` 를 통해 서버에 번역 요청
```swift
let targetLang = Locale.preferredLanguages.first?.components(separatedBy: "-").first ?? "en"

if targetLang == "ko" {
    self.translatedTitle = question.title
    self.translatedContent = question.content
    return
}

APIService().translateText(text: question.title, target: targetLang) { ... }
APIService().translateText(text: question.content, target: targetLang) { ... }
```

3. `APIService.swift`
- NestJS 서버 `/translate` 엔드포인트로 번역 요청 보내는 메서드 추가
```swift
func translateText  ...
      ...
```

## 💬 공유사항 to 리뷰어

- 사용자 기기 설정이 한국어로 되어있으면 번역되지 않게 해두었습니다. 좋지요~?
- 프론트에 구글 번역 api테스트할 때는 지연시간 없었는데,, 백엔드에 구글 api 연동하는걸로 수정 후엔 테스트 안해봤슴다. 로딩 시간 생기려나?

## 📚 참고자료
https://cloud.google.com/translate/docs/reference/rest/?apix=true
