### PR TITLE
[feat] 마이페이지 구현

### DIFF
--- a/worlds-fe-v20/Info.plist
+++ b/worlds-fe-v20/Info.plist
@@ -24,6 +24,14 @@
 	<string>$(API_SIGNUP_URL)</string>
 	<key>APIUserInfoURL</key>
 	<string>$(API_USER_INFO_URL)</string>
+	<key>APIOCRURL</key>
+	<string>$(API_OCR_URL)</string>
+	<key>APIOCRSolutionURL</key>
+	<string>$(API_OCR_SOLUTION_URL)</string>
+	<key>APIMyQuestionURL</key>
+	<string>$(API_MY_QUESTION_URL)</string>
+	<key>APIDeleteAccountURL</key>
+	<string>$(API_DELETE_ACCOUNT_URL)</string>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>

--- a/worlds-fe-v20/Models/APIResponse.swift
+++ b/worlds-fe-v20/Models/APIResponse.swift
@@ -14,10 +14,11 @@ struct APIResponse: Codable {
     var userInfo: User?
     var userEmail: String?
     var username: String?
+    var withdrawalReason: String?
     
     enum CodingKeys: String, CodingKey {
         case accessToken = "access_token"
         case refreshToken = "refresh_token"
-        case error, statusCode, message, userInfo, userEmail, username
+        case error, statusCode, message, userInfo, userEmail, username, withdrawalReason
     }
 }

--- a/worlds-fe-v20/Models/MenteeTranslation.swift
+++ b/worlds-fe-v20/Models/MenteeTranslation.swift
@@ -1,0 +1,17 @@
+//
+//  MenteeTranslation.swift
+//  worlds-fe-v20
+//
+//  Created by seohuibaek on 8/4/25.
+//
+
+struct MenteeTranslation: Codable, Hashable {
+    let id: Int
+    let menteeId: Int
+    let originalText: [String]
+    let translatedText: [String]
+    let createdAt: String
+    let keyConcept: String
+    let solution: String
+    let summary: String
+}

--- a/worlds-fe-v20/Models/Question.swift
+++ b/worlds-fe-v20/Models/Question.swift
@@ -69,7 +69,7 @@ struct QuestionUser: Codable, Hashable {
     let id: Int
     let name: String
     let email: String
-    let role: Bool
+    let role: Bool?
     
     enum CodingKeys: String, CodingKey {
         case id

--- a/worlds-fe-v20/Models/User.swift
+++ b/worlds-fe-v20/Models/User.swift
@@ -14,5 +14,5 @@ struct User: Codable, Hashable, Identifiable {
     let birthday: String
     let isMentor: Bool
     let reportCount: Int
-    let menteeTranslations: [String?]
+    let menteeTranslations: [MenteeTranslation]
 }

--- a/worlds-fe-v20/Services/UserAPIManager.swift
+++ b/worlds-fe-v20/Services/UserAPIManager.swift
@@ -101,7 +101,7 @@ class UserAPIManager {
                 print("디코딩 에러: \(error.localizedDescription)")
 
                 if let rawJSON = String(data: data, encoding: .utf8) {
-                    print("원본 JSON 응답:\n\(rawJSON)")
+                    // print("원본 JSON 응답:\n\(rawJSON)")
                 }
                 
                 throw UserAPIError.decodingError(description: "디코딩 실패: \(error)")
@@ -294,6 +294,7 @@ class UserAPIManager {
                 
                 UserDefaults.standard.removeObject(forKey: "accessToken")
                 UserDefaults.standard.removeObject(forKey: "refreshToken")
+                UserDefaults.standard.removeObject(forKey: "username")
                 
                 return response
             } catch {
@@ -302,6 +303,73 @@ class UserAPIManager {
             
         case .failure:
             throw UserAPIError.serverError(message: "서버 응답 파싱 실패")
+        }
+    }
+    
+    // 회원탈퇴
+    // 스웨거에서는 되는데 여기선 안댐..
+    func deleteAccount(withdrawalReason: String = "personal") async throws -> APIResponse {
+        guard let token = UserDefaults.standard.string(forKey: "accessToken") else {
+            print("토큰 값이 유효하지 않습니다.")
+            throw UserAPIError.invalidToken
+        }
+        
+        print("현재 토큰: \(token)")
+        
+        guard let endPoint = Bundle.main.object(forInfoDictionaryKey: "APIDeleteAccountURL") as? String else {
+            throw UserAPIError.invalidEndPoint
+        }
+                
+        let headers: HTTPHeaders = ["Authorization": "Bearer \(token)"]
+        
+        print("요청 헤더: \(headers)")
+        
+        let parameters: [String: Any] = [
+            "withdrawalReason": withdrawalReason
+        ]
+        
+        print("요청 파라미터: \(parameters)")
+        
+        let dataResponse = await AF.request(endPoint, method: .delete, parameters: parameters, encoding: JSONEncoding.default, headers: headers)
+            .validate()
+            .serializingData()
+            .response
+                
+        switch dataResponse.result {
+        case .success(let data):
+            do {
+                let response = try JSONDecoder().decode(APIResponse.self, from: data)
+                print("회원탈퇴 정보: \(response)")
+                
+                UserDefaults.standard.removeObject(forKey: "accessToken")
+                UserDefaults.standard.removeObject(forKey: "refreshToken")
+                UserDefaults.standard.removeObject(forKey: "username")
+                
+                return response
+            } catch {
+                print("디코딩 에러: \(error.localizedDescription)")
+                
+                if let rawJSON = String(data: data, encoding: .utf8) {
+                     print("회원탈퇴 원본 JSON 응답:\n\(rawJSON)")
+                }
+                
+                throw UserAPIError.decodingError(description: "디코딩 실패: \(error)")
+            }
+            
+        case .failure:
+            if let rawData = dataResponse.data,
+               let rawString = String(data: rawData, encoding: .utf8) {
+                print("회원탈퇴 서버 원본 응답: \(rawString)")
+                
+                // 서버 에러 응답 파싱 시도
+                let errorResponse = try JSONDecoder().decode(APIErrorResponse.self, from: rawData)
+                print("회원탈퇴 파싱된 에러 응답: \(errorResponse)")
+                
+                let errorMessage = errorResponse.message[0]
+                throw UserAPIError.serverError(message: errorMessage)
+            } else {
+                throw UserAPIError.serverError(message: "회원탈퇴 서버 응답 파싱 실패")
+            }
         }
     }
     
@@ -328,7 +396,7 @@ class UserAPIManager {
             do {
                 let response = try JSONDecoder().decode(APIResponse.self, from: data)
                 
-                print("사용자 정보: \(response)")
+                // print("사용자 정보: \(response)")
                 
                 return response
             } catch {
@@ -518,6 +586,27 @@ class UserAPIManager {
                 throw UserAPIError.serverError(message: "서버 응답 파싱 실패")
             }
         }
+    }
+    
+    //내가 한 질문 목록 조회 -> 추후 API Service로 이동
+    func getMyQuestions() async throws -> QuestionResponse {
+        
+        guard let token = UserDefaults.standard.string(forKey: "accessToken") else {
+            print("토큰 값이 유효하지 않습니다.")
+            throw UserAPIError.invalidToken
+        }
+        
+        guard let endPoint = Bundle.main.object(forInfoDictionaryKey: "APIMYQUESTIONS") as? String else {
+            throw UserAPIError.invalidEndPoint
+        }
+                
+        let headers: HTTPHeaders = ["Authorization": "Bearer \(token)"]
+              
+        let response = try await AF.request(endPoint, method: .get, headers: headers)
+            .serializingDecodable(QuestionResponse.self)
+            .value
+        
+        return response
     }
 }
 

--- a/worlds-fe-v20/Services/UserAPIManager.swift
+++ b/worlds-fe-v20/Services/UserAPIManager.swift
@@ -307,7 +307,6 @@ class UserAPIManager {
     }
     
     // 회원탈퇴
-    // 스웨거에서는 되는데 여기선 안댐..
     func deleteAccount(withdrawalReason: String = "personal") async throws -> APIResponse {
         guard let token = UserDefaults.standard.string(forKey: "accessToken") else {
             print("토큰 값이 유효하지 않습니다.")
@@ -589,21 +588,21 @@ class UserAPIManager {
     }
     
     //내가 한 질문 목록 조회 -> 추후 API Service로 이동
-    func getMyQuestions() async throws -> QuestionResponse {
+    func getMyQuestions() async throws -> [QuestionList] {
         
         guard let token = UserDefaults.standard.string(forKey: "accessToken") else {
             print("토큰 값이 유효하지 않습니다.")
             throw UserAPIError.invalidToken
         }
         
-        guard let endPoint = Bundle.main.object(forInfoDictionaryKey: "APIMYQUESTIONS") as? String else {
+        guard let endPoint = Bundle.main.object(forInfoDictionaryKey: "APIMyQuestionURL") as? String else {
             throw UserAPIError.invalidEndPoint
         }
                 
         let headers: HTTPHeaders = ["Authorization": "Bearer \(token)"]
               
         let response = try await AF.request(endPoint, method: .get, headers: headers)
-            .serializingDecodable(QuestionResponse.self)
+            .serializingDecodable([QuestionList].self)
             .value
         
         return response

--- a/worlds-fe-v20/ViewModels/MainViewModel.swift
+++ b/worlds-fe-v20/ViewModels/MainViewModel.swift
@@ -25,7 +25,7 @@ final class MainViewModel: ObservableObject {
             self.posts = posts
             self.errorMessage = nil
         } catch {
-            print("❌ 에러 발생:", error)
+            print("❌ fetchLatestPosts 에러 발생:", error)
             self.errorMessage = "질문 최신 목록을 불러오는데 실패했습니다: \(error.localizedDescription)"
         }
     }

--- a/worlds-fe-v20/ViewModels/MyPageViewModel.swift
+++ b/worlds-fe-v20/ViewModels/MyPageViewModel.swift
@@ -1,0 +1,64 @@
+//
+//  MyPageViewModel.swift
+//  worlds-fe-v20
+//
+//  Created by seohuibaek on 8/4/25.
+//
+
+import SwiftUI
+
+final class MyPageViewModel: ObservableObject {
+    @Published var errorMessage: String?
+    @Published var questions: [QuestionList] = []
+    @Published var userInfo: User?
+    
+    @MainActor
+    func fetchMyInformation() async {
+        do {
+            let userInfo = try await UserAPIManager.shared.getUserInfo()
+            self.userInfo = userInfo.userInfo
+            self.errorMessage = nil
+        } catch {
+            print("❌  fetchMyInformation 에러 발생:", error)
+            self.errorMessage = "사용자 정보를 불러오는데 실패했습니다: \(error.localizedDescription)"
+        }
+    }
+    
+    @MainActor
+    func fetchMyQuestions() async {
+        do {
+            let response = try await UserAPIManager.shared.getMyQuestions()
+            guard let questions = response.data as? [QuestionList] else {
+                fatalError("Unexpected response format")
+            }
+            self.questions = questions
+            print("\(questions)")
+            self.errorMessage = nil
+        } catch {
+            print("❌ fetchMyQuestions 에러 발생:", error)
+            self.errorMessage = "질문 목록을 불러오는데 실패했습니다: \(error.localizedDescription)"
+        }
+    }
+    
+    @MainActor
+    func logout() async {
+        do {
+            let userInfo = try await UserAPIManager.shared.logout()
+            self.errorMessage = nil
+        } catch {
+            print("❌ logout 에러 발생:", error)
+            self.errorMessage = "로그아웃에 실패했습니다: \(error.localizedDescription)"
+        }
+    }
+    
+    @MainActor
+    func deleteAccount() async {
+        do {
+            let userInfo = try await UserAPIManager.shared.deleteAccount()
+            self.errorMessage = nil
+        } catch {
+            print("❌ deleteAccount 에러 발생:", error)
+            self.errorMessage = "회원탈퇴에 실패했습니다: \(error.localizedDescription)"
+        }
+    }
+}

--- a/worlds-fe-v20/ViewModels/MyPageViewModel.swift
+++ b/worlds-fe-v20/ViewModels/MyPageViewModel.swift
@@ -27,10 +27,7 @@ final class MyPageViewModel: ObservableObject {
     @MainActor
     func fetchMyQuestions() async {
         do {
-            let response = try await UserAPIManager.shared.getMyQuestions()
-            guard let questions = response.data as? [QuestionList] else {
-                fatalError("Unexpected response format")
-            }
+            let questions = try await UserAPIManager.shared.getMyQuestions()
             self.questions = questions
             print("\(questions)")
             self.errorMessage = nil

--- a/worlds-fe-v20/Views/Main/MainView.swift
+++ b/worlds-fe-v20/Views/Main/MainView.swift
@@ -14,109 +14,107 @@ struct MainView: View {
     @State private var attendanceData: [Int: Bool] = [:]
     
     var body: some View {
-        NavigationStack {
-            ScrollView {
+        ScrollView {
+            VStack {
                 VStack {
-                    VStack {
-                        Text("안녕하세요! \(viewModel.getUsername())님")
-                            .font(.system(size: 27))
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                            .padding(.horizontal, 24)
+                    Text("안녕하세요! \(viewModel.getUsername())님")
+                        .font(.system(size: 27))
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(.horizontal, 24)
+                    
+                    // 출석 체크 화면
+                    ZStack() {
+                        RoundedRectangle(cornerRadius: 16)
+                            .fill(Color.white)
+                            .frame(height: 120)
+                            .frame(maxWidth: .infinity)
+                            .shadow(color: .black.opacity(0.25), radius: 4, x: 0, y: 4)
                         
-                        // 출석 체크 화면
-                        ZStack() {
-                            RoundedRectangle(cornerRadius: 16)
-                                .fill(Color.white)
-                                .frame(height: 120)
-                                .frame(maxWidth: .infinity)
-                                .shadow(color: .black.opacity(0.25), radius: 4, x: 0, y: 4)
-                            
-                            HStack() {
-                                ForEach(1...7, id: \.self) { weekday in
-                                    AttendanceRowView(
-                                        weekday: weekday,
-                                        isAttended: attendanceData[weekday] ?? true,
-                                        isToday: weekday == Calendar.current.component(.weekday, from: Date()))
-                                }
+                        HStack() {
+                            ForEach(1...7, id: \.self) { weekday in
+                                AttendanceRowView(
+                                    weekday: weekday,
+                                    isAttended: attendanceData[weekday] ?? true,
+                                    isToday: weekday == Calendar.current.component(.weekday, from: Date()))
                             }
                         }
-                        .padding(.horizontal, 24)
                     }
-                    .background(
-                        Rectangle()
-                            .fill(Color.sub2Ws)
-                            .padding(.bottom, 60)
-                            .padding(.top, -120)
-                    )
-                    .padding(.vertical, 40)
-                    
-                    HStack() {
-                        Text("이번주 소식")
-                            .font(.system(size: 27))
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                            .padding(.horizontal, 24)
-                            .padding(.bottom, 20)
-                        
-                        NavigationLink(destination: CultureDetailView()) {
-                            Text("더보기 >")
-                                .font(.system(size: 16))
-                                .foregroundStyle(Color.mainws)
-                                .padding(.horizontal, 24)
-                                .padding(.bottom, 20)
-                        }
-                    }
-                    
-                    AutoSlideViewWithTimer()
-                        .frame(height: 300)
-                        .padding(.horizontal, 24)
-                    
-                    Text("최신글")
+                    .padding(.horizontal, 24)
+                }
+                .background(
+                    Rectangle()
+                        .fill(Color.sub2Ws)
+                        .padding(.bottom, 60)
+                        .padding(.top, -120)
+                )
+                .padding(.vertical, 40)
+                
+                HStack() {
+                    Text("이번주 소식")
                         .font(.system(size: 27))
                         .frame(maxWidth: .infinity, alignment: .leading)
                         .padding(.horizontal, 24)
                         .padding(.bottom, 20)
                     
-                    VStack(spacing: 16) {
-                        Spacer()
-                        
-                        ForEach(viewModel.posts.prefix(5), id: \.self) { post in
-                            NavigationLink(destination: QuestionDetailView(questionId: post.id, viewModel: QuestionViewModel())) {
-                                
-                                HStack(spacing: 40){
-                                    Text("\(post.category.displayName)")
-                                        .font(.system(size: 18))
-                                        .foregroundStyle(Color.black)
-                                        .frame(width: 40, alignment: .leading)
-                                    
-                                    Text("\(post.title)")
-                                        .font(.system(size: 18))
-                                        .foregroundStyle(Color.black)
-                                        .lineLimit(1)
-                                        .truncationMode(.tail)
-                                        .frame(maxWidth: .infinity, alignment: .leading)
-                                }
-                                .padding(.horizontal, 48)
-                                
-                            }
-                        }
-                        
-                        Spacer()
-                    }
-                    .background(
-                        RoundedRectangle(cornerRadius: 16)
-                            .fill(.backgroundws)
+                    NavigationLink(destination: CultureDetailView()) {
+                        Text("더보기 >")
+                            .font(.system(size: 16))
+                            .foregroundStyle(Color.mainws)
                             .padding(.horizontal, 24)
-                            .shadow(color: .black.opacity(0.25), radius: 4, x: 4, y: 4)
-                    )
+                            .padding(.bottom, 20)
+                    }
                 }
-                .padding(.bottom, 100)
-                .background(Color.white)
+                
+                AutoSlideViewWithTimer()
+                    .frame(height: 300)
+                    .padding(.horizontal, 24)
+                
+                Text("최신글")
+                    .font(.system(size: 27))
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.horizontal, 24)
+                    .padding(.bottom, 20)
+                
+                VStack(spacing: 16) {
+                    Spacer()
+                    
+                    ForEach(viewModel.posts.prefix(5), id: \.self) { post in
+                        NavigationLink(destination: QuestionDetailView(questionId: post.id, viewModel: QuestionViewModel())) {
+                            
+                            HStack(spacing: 40){
+                                Text("\(post.category.displayName)")
+                                    .font(.system(size: 18))
+                                    .foregroundStyle(Color.black)
+                                    .frame(width: 40, alignment: .leading)
+                                
+                                Text("\(post.title)")
+                                    .font(.system(size: 18))
+                                    .foregroundStyle(Color.black)
+                                    .lineLimit(1)
+                                    .truncationMode(.tail)
+                                    .frame(maxWidth: .infinity, alignment: .leading)
+                            }
+                            .padding(.horizontal, 48)
+                            
+                        }
+                    }
+                    
+                    Spacer()
+                }
+                .background(
+                    RoundedRectangle(cornerRadius: 16)
+                        .fill(.backgroundws)
+                        .padding(.horizontal, 24)
+                        .shadow(color: .black.opacity(0.25), radius: 4, x: 4, y: 4)
+                )
             }
-            .scrollIndicators(.hidden)
-            .onAppear {
-                Task {
-                    await viewModel.fetchLatestPosts()
-                }
+            .padding(.bottom, 100)
+            .background(Color.white)
+        }
+        .scrollIndicators(.hidden)
+        .onAppear {
+            Task {
+                await viewModel.fetchLatestPosts()
             }
         }
     }

--- a/worlds-fe-v20/Views/MyPage/DeleteAccountView.swift
+++ b/worlds-fe-v20/Views/MyPage/DeleteAccountView.swift
@@ -1,0 +1,63 @@
+//
+//  DeleteAccountView.swift
+//  worlds-fe-v20
+//
+//  Created by seohuibaek on 8/1/25.
+//
+
+import SwiftUI
+
+struct DeleteAccountView: View {
+    
+    @Environment(\.dismiss) var dismiss
+    
+    var body: some View {
+        VStack {
+            Text("탈퇴 하시겠습니까?")
+                .font(.system(size: 32, weight: .bold))
+                .foregroundStyle(.black)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding()
+            
+            Text("탈퇴할 경우, 모든 데이터는 삭제되며 다시 복구되지 않습니다.")
+                .font(.system(size: 20))
+                .foregroundStyle(.gray)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding()
+            
+            Spacer()
+            
+            Button {
+                
+            } label: {
+                ZStack {
+                    RoundedRectangle(cornerRadius: 10)
+                        .fill(Color.red)
+                        .frame(height: 60)
+                        .shadow(color: .black.opacity(0.25), radius: 4, x: 4, y: 4)
+                    
+                    HStack {
+                        Text("회원탈퇴")
+                    }
+                    .font(.system(size: 20, weight: .bold))
+                    .foregroundStyle(.white)
+                }
+            }
+            .padding()
+        }
+        .navigationTitle("회원탈퇴")
+        .navigationBarTitleDisplayMode(.inline)
+        .navigationBarBackButtonHidden(true)
+        .toolbar {
+            ToolbarItem(placement: .navigationBarLeading) {
+                Button {
+                    dismiss()
+                } label: {
+                    Image(systemName: "chevron.left")
+                        .foregroundColor(.mainws)
+                        .font(.system(size: 18, weight: .semibold))
+                }
+            }
+        }
+    }
+}

--- a/worlds-fe-v20/Views/MyPage/DeleteAccountView.swift
+++ b/worlds-fe-v20/Views/MyPage/DeleteAccountView.swift
@@ -8,7 +8,8 @@
 import SwiftUI
 
 struct DeleteAccountView: View {
-    
+    @StateObject var viewModel: MyPageViewModel = MyPageViewModel()
+    @EnvironmentObject var appState: AppState
     @Environment(\.dismiss) var dismiss
     
     var body: some View {
@@ -28,7 +29,10 @@ struct DeleteAccountView: View {
             Spacer()
             
             Button {
-                
+                Task {
+                    await viewModel.deleteAccount()
+                    appState.flow = .login
+                }
             } label: {
                 ZStack {
                     RoundedRectangle(cornerRadius: 10)

--- a/worlds-fe-v20/Views/MyPage/MyPageView.swift
+++ b/worlds-fe-v20/Views/MyPage/MyPageView.swift
@@ -1,0 +1,117 @@
+//
+//  MyPageView.swift
+//  worlds-fe-v20
+//
+//  Created by seohuibaek on 7/31/25.
+//
+
+import SwiftUI
+
+struct MyPageView: View {
+    @Environment(\.openURL) var openURL
+    
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                Color.sub2Ws
+                    .ignoresSafeArea()
+                
+                VStack {
+                    VStack {
+                        Text("마이페이지")
+                            .font(.system(size: 27))
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(.horizontal, 24)
+                        
+                        UserInfoCardView()
+                            .cornerRadius(20)
+                            .shadow(color: .black.opacity(0.25), radius: 4, x: 4, y: 4)
+                            .padding(.horizontal, 16)
+                    }
+                    .padding(.vertical, 40)
+                    
+                    VStack(spacing: 16) {
+                        NavigationLink(destination: MyQuestionView()) {
+                            Text("내가 쓴 글")
+                                .font(.system(size: 18))
+                                .foregroundStyle(Color.black)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                        }
+                        .padding(.horizontal, 32)
+                        
+                        Divider()
+                            .padding(.horizontal, 32)
+                        
+                        NavigationLink(destination: UserInfoCardView()) {
+                            Text("로그아웃")
+                                .font(.system(size: 18))
+                                .foregroundStyle(Color.black)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                        }
+                        .padding(.horizontal, 32)
+                        
+                        Divider()
+                            .padding(.horizontal, 32)
+                        
+                        Link("이용약관", destination: URL(string: "https://www.notion.so/World-Study-_2-0-0-1fc800c9877b80d6a86ce296013ec7d7?source=copy_link")!)
+                            .font(.system(size: 18))
+                            .foregroundStyle(Color.black)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(.horizontal, 32)
+                        
+                        Divider()
+                            .padding(.horizontal, 32)
+                        
+                        HStack {
+                            Text("버전 정보")
+                                .font(.system(size: 18))
+                                .foregroundStyle(Color.black)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                            
+                            Spacer()
+                            
+                            Text("\(appVersion())")
+                                .font(.system(size: 18))
+                                .foregroundStyle(Color.gray)
+                                .frame(maxWidth: .infinity, alignment: .trailing)
+                        }
+                        .padding(.horizontal, 32)
+                        
+                        Divider()
+                            .padding(.horizontal, 32)
+                        
+                        NavigationLink(destination: DeleteAccountView()) {
+                            Text("회원탈퇴")
+                                .font(.system(size: 18))
+                                .foregroundStyle(Color.red)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                        }
+                        .padding(.horizontal, 32)
+                    }
+                    .padding(.vertical, 24)
+                    .background(
+                        RoundedRectangle(cornerRadius: 16)
+                            .fill(.backgroundws)
+                            .padding(.horizontal, 16)
+                            .shadow(color: .black.opacity(0.25), radius: 4, x: 4, y: 4)
+                    )
+                }
+                .padding(.bottom, 100)
+            }
+        }
+    }
+}
+
+extension MyPageView {
+    private func appVersion() -> String {
+        guard let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String else {
+            return "알 수 없음"
+        }
+        
+        return version
+    }
+}
+
+#Preview {
+    MyPageView()
+}

--- a/worlds-fe-v20/Views/MyPage/MyPageView.swift
+++ b/worlds-fe-v20/Views/MyPage/MyPageView.swift
@@ -11,93 +11,91 @@ struct MyPageView: View {
     @Environment(\.openURL) var openURL
     
     var body: some View {
-        NavigationStack {
-            ZStack {
-                Color.sub2Ws
-                    .ignoresSafeArea()
-                
+        ZStack {
+            Color.sub2Ws
+                .ignoresSafeArea()
+            
+            VStack {
                 VStack {
-                    VStack {
-                        Text("마이페이지")
-                            .font(.system(size: 27))
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                            .padding(.horizontal, 24)
-                        
-                        UserInfoCardView()
-                            .cornerRadius(20)
-                            .shadow(color: .black.opacity(0.25), radius: 4, x: 4, y: 4)
-                            .padding(.horizontal, 16)
-                    }
-                    .padding(.vertical, 40)
+                    Text("마이페이지")
+                        .font(.system(size: 27))
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(.horizontal, 24)
                     
-                    VStack(spacing: 16) {
-                        NavigationLink(destination: MyQuestionView()) {
-                            Text("내가 쓴 글")
-                                .font(.system(size: 18))
-                                .foregroundStyle(Color.black)
-                                .frame(maxWidth: .infinity, alignment: .leading)
-                        }
-                        .padding(.horizontal, 32)
-                        
-                        Divider()
-                            .padding(.horizontal, 32)
-                        
-                        NavigationLink(destination: UserInfoCardView()) {
-                            Text("로그아웃")
-                                .font(.system(size: 18))
-                                .foregroundStyle(Color.black)
-                                .frame(maxWidth: .infinity, alignment: .leading)
-                        }
-                        .padding(.horizontal, 32)
-                        
-                        Divider()
-                            .padding(.horizontal, 32)
-                        
-                        Link("이용약관", destination: URL(string: "https://www.notion.so/World-Study-_2-0-0-1fc800c9877b80d6a86ce296013ec7d7?source=copy_link")!)
+                    UserInfoCardView()
+                        .cornerRadius(20)
+                        .shadow(color: .black.opacity(0.25), radius: 4, x: 4, y: 4)
+                        .padding(.horizontal, 16)
+                }
+                .padding(.vertical, 40)
+                
+                VStack(spacing: 16) {
+                    NavigationLink(destination: MyQuestionView()) {
+                        Text("내가 쓴 글")
                             .font(.system(size: 18))
                             .foregroundStyle(Color.black)
                             .frame(maxWidth: .infinity, alignment: .leading)
-                            .padding(.horizontal, 32)
-                        
-                        Divider()
-                            .padding(.horizontal, 32)
-                        
-                        HStack {
-                            Text("버전 정보")
-                                .font(.system(size: 18))
-                                .foregroundStyle(Color.black)
-                                .frame(maxWidth: .infinity, alignment: .leading)
-                            
-                            Spacer()
-                            
-                            Text("\(appVersion())")
-                                .font(.system(size: 18))
-                                .foregroundStyle(Color.gray)
-                                .frame(maxWidth: .infinity, alignment: .trailing)
-                        }
-                        .padding(.horizontal, 32)
-                        
-                        Divider()
-                            .padding(.horizontal, 32)
-                        
-                        NavigationLink(destination: DeleteAccountView()) {
-                            Text("회원탈퇴")
-                                .font(.system(size: 18))
-                                .foregroundStyle(Color.red)
-                                .frame(maxWidth: .infinity, alignment: .leading)
-                        }
-                        .padding(.horizontal, 32)
                     }
-                    .padding(.vertical, 24)
-                    .background(
-                        RoundedRectangle(cornerRadius: 16)
-                            .fill(.backgroundws)
-                            .padding(.horizontal, 16)
-                            .shadow(color: .black.opacity(0.25), radius: 4, x: 4, y: 4)
-                    )
+                    .padding(.horizontal, 32)
+                    
+                    Divider()
+                        .padding(.horizontal, 32)
+                    
+                    NavigationLink(destination: UserInfoCardView()) {
+                        Text("로그아웃")
+                            .font(.system(size: 18))
+                            .foregroundStyle(Color.black)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                    .padding(.horizontal, 32)
+                    
+                    Divider()
+                        .padding(.horizontal, 32)
+                    
+                    Link("이용약관", destination: URL(string: "https://www.notion.so/World-Study-_2-0-0-1fc800c9877b80d6a86ce296013ec7d7?source=copy_link")!)
+                        .font(.system(size: 18))
+                        .foregroundStyle(Color.black)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(.horizontal, 32)
+                    
+                    Divider()
+                        .padding(.horizontal, 32)
+                    
+                    HStack {
+                        Text("버전 정보")
+                            .font(.system(size: 18))
+                            .foregroundStyle(Color.black)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                        
+                        Spacer()
+                        
+                        Text("\(appVersion())")
+                            .font(.system(size: 18))
+                            .foregroundStyle(Color.gray)
+                            .frame(maxWidth: .infinity, alignment: .trailing)
+                    }
+                    .padding(.horizontal, 32)
+                    
+                    Divider()
+                        .padding(.horizontal, 32)
+                    
+                    NavigationLink(destination: DeleteAccountView()) {
+                        Text("회원탈퇴")
+                            .font(.system(size: 18))
+                            .foregroundStyle(Color.red)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                    .padding(.horizontal, 32)
                 }
-                .padding(.bottom, 100)
+                .padding(.vertical, 24)
+                .background(
+                    RoundedRectangle(cornerRadius: 16)
+                        .fill(.backgroundws)
+                        .padding(.horizontal, 16)
+                        .shadow(color: .black.opacity(0.25), radius: 4, x: 4, y: 4)
+                )
             }
+            .padding(.bottom, 100)
         }
     }
 }

--- a/worlds-fe-v20/Views/MyPage/MyPageView.swift
+++ b/worlds-fe-v20/Views/MyPage/MyPageView.swift
@@ -44,7 +44,7 @@ struct MyPageView: View {
                     .padding(.horizontal, 32)
                     .onAppear{
                         Task {
-                            // await viewModel.fetchMyQuestions()
+                            await viewModel.fetchMyQuestions()
                         }
                     }
                     

--- a/worlds-fe-v20/Views/MyPage/MyPageView.swift
+++ b/worlds-fe-v20/Views/MyPage/MyPageView.swift
@@ -9,7 +9,12 @@ import SwiftUI
 
 struct MyPageView: View {
     @Environment(\.openURL) var openURL
+    @StateObject var viewModel: MyPageViewModel = MyPageViewModel()
     
+    @State private var showAlert = false
+    @State private var alertMessage = ""
+    @EnvironmentObject var appState: AppState
+
     var body: some View {
         ZStack {
             Color.sub2Ws
@@ -22,7 +27,7 @@ struct MyPageView: View {
                         .frame(maxWidth: .infinity, alignment: .leading)
                         .padding(.horizontal, 24)
                     
-                    UserInfoCardView()
+                    UserInfoCardView(userInfo: viewModel.userInfo)
                         .cornerRadius(20)
                         .shadow(color: .black.opacity(0.25), radius: 4, x: 4, y: 4)
                         .padding(.horizontal, 16)
@@ -30,24 +35,41 @@ struct MyPageView: View {
                 .padding(.vertical, 40)
                 
                 VStack(spacing: 16) {
-                    NavigationLink(destination: MyQuestionView()) {
+                    NavigationLink(destination: MyQuestionView(questions: viewModel.questions)) {
                         Text("내가 쓴 글")
                             .font(.system(size: 18))
                             .foregroundStyle(Color.black)
                             .frame(maxWidth: .infinity, alignment: .leading)
                     }
                     .padding(.horizontal, 32)
+                    .onAppear{
+                        Task {
+                            // await viewModel.fetchMyQuestions()
+                        }
+                    }
                     
                     Divider()
                         .padding(.horizontal, 32)
                     
-                    NavigationLink(destination: UserInfoCardView()) {
+                    Button {
+                        alertMessage = "로그아웃 하시겠습니까?"
+                        showAlert = true
+                    } label: {
                         Text("로그아웃")
                             .font(.system(size: 18))
                             .foregroundStyle(Color.black)
                             .frame(maxWidth: .infinity, alignment: .leading)
                     }
                     .padding(.horizontal, 32)
+                    .alert(alertMessage, isPresented: $showAlert) {
+                        Button("확인", role: .cancel) {
+                            Task {
+                                await viewModel.logout()
+                                appState.flow = .login
+                            }
+                        }
+                        Button("취소", role: .destructive) { }
+                    }
                     
                     Divider()
                         .padding(.horizontal, 32)
@@ -97,6 +119,12 @@ struct MyPageView: View {
             }
             .padding(.bottom, 100)
         }
+        .onAppear {
+            // 정보 불러오기
+            Task {
+                await viewModel.fetchMyInformation()
+            }
+        }
     }
 }
 
@@ -110,6 +138,6 @@ extension MyPageView {
     }
 }
 
-#Preview {
-    MyPageView()
-}
+//#Preview {
+//    MyPageView()
+//}

--- a/worlds-fe-v20/Views/MyPage/MyQuestionView.swift
+++ b/worlds-fe-v20/Views/MyPage/MyQuestionView.swift
@@ -1,0 +1,140 @@
+//
+//  MyQuestionView.swift
+//  worlds-fe-v20
+//
+//  Created by seohuibaek on 8/1/25.
+//
+
+import SwiftUI
+
+struct MyQuestionView: View {
+    
+    @Environment(\.dismiss) var dismiss
+    
+    var questions: [QuestionList] = []
+    
+    let dummyQuestionList: [QuestionList] = [
+        QuestionList(
+            id: 1,
+            title: "SwiftUI에서 배경 색상 전체 적용 안 될 때",
+            content: "ZStack을 사용하라는 말을 들었는데 잘 안되네요. 어떻게 배경을 전체에 적용하죠?",
+            createdAt: "2025-08-01T09:30:00",
+            isAnswered: true,
+            answerCount: 3,
+            category: .study,
+            user: QuestionUser(
+                id: 101,
+                name: "서하",
+                email: "seoha@example.com",
+                role: false
+            ),
+            imageUrls: [
+                "https://example.com/image/question1_1.png"
+            ]
+        ),
+        QuestionList(
+            id: 2,
+            title: "Swift 네이밍 관련 질문 있어요",
+            content: "프로퍼티 이름을 카멜케이스로 짓는 게 맞는 건가요? 코딩 컨벤션에 대해 궁금합니다.",
+            createdAt: "2025-07-30T14:20:00",
+            isAnswered: false,
+            answerCount: 0,
+            category: .free,
+            user: QuestionUser(
+                id: 102,
+                name: "지민",
+                email: "jimin@mail.com",
+                role: false
+            ),
+            imageUrls: nil
+        ),
+        QuestionList(
+            id: 3,
+            title: "ViewModel에서 API 호출 시점 질문",
+            content: "onAppear에서 fetch를 해도 될까요? 아니면 init에서 하는 편이 더 나을까요?",
+            createdAt: "2025-07-28T18:45:00",
+            isAnswered: true,
+            answerCount: 5,
+            category: .study,
+            user: QuestionUser(
+                id: 103,
+                name: "영우",
+                email: "youngwoo@worlds.io",
+                role: true
+            ),
+            imageUrls: [
+                "https://example.com/image/question3_1.png",
+                "https://example.com/image/question3_2.png"
+            ]
+        ),
+        QuestionList(
+            id: 4,
+            title: "자유게시판에 글 쓰는 연습입니다",
+            content: "이 게시판은 테스트용으로 마음껏 글 올려도 되나요?",
+            createdAt: "2025-07-26T16:00:00",
+            isAnswered: false,
+            answerCount: 1,
+            category: .free,
+            user: QuestionUser(
+                id: 104,
+                name: "민준",
+                email: "minjun@domain.com",
+                role: false
+            ),
+            imageUrls: nil
+        ),
+        QuestionList(
+            id: 5,
+            title: "iOS NavigationLink 디버깅 도움 요청합니다",
+            content: "탭 했을 때 화면이 안 넘어가거나 이상한 화면이 뜰 때, 디버깅 방법 추천해주실 분~?",
+            createdAt: "2025-07-25T22:10:00",
+            isAnswered: true,
+            answerCount: 2,
+            category: .study,
+            user: QuestionUser(
+                id: 105,
+                name: "지원",
+                email: "jiwon@sample.com",
+                role: true
+            ),
+            imageUrls: [
+                "https://example.com/image/question5_1.png"
+            ]
+        )
+    ]
+
+    
+    var body: some View {
+        ZStack {
+            Color.backgroundws
+                .ignoresSafeArea()
+            ScrollView {
+                VStack(spacing: 18) {
+                    ForEach(dummyQuestionList) { question in
+                        NavigationLink(destination: QuestionDetailView(questionId: question.id, viewModel: QuestionViewModel())
+                            .environmentObject(CommentViewModel())) {
+                                QuestionCard(question: question)
+                            }
+                            .buttonStyle(PlainButtonStyle())
+                    }
+                }
+                .padding(.top, 8)
+                .padding(.horizontal, 20)
+            }
+            .navigationTitle("내가 쓴 글")
+            .navigationBarTitleDisplayMode(.inline)
+            .navigationBarBackButtonHidden(true)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button {
+                        dismiss()
+                    } label: {
+                        Image(systemName: "chevron.left")
+                            .foregroundColor(.mainws)
+                            .font(.system(size: 18, weight: .semibold))
+                    }
+                }
+            }
+        }
+    }
+}

--- a/worlds-fe-v20/Views/MyPage/MyQuestionView.swift
+++ b/worlds-fe-v20/Views/MyPage/MyQuestionView.swift
@@ -11,98 +11,7 @@ struct MyQuestionView: View {
     
     @Environment(\.dismiss) var dismiss
     
-    var questions: [QuestionList] = []
-    
-    let dummyQuestionList: [QuestionList] = [
-        QuestionList(
-            id: 1,
-            title: "SwiftUI에서 배경 색상 전체 적용 안 될 때",
-            content: "ZStack을 사용하라는 말을 들었는데 잘 안되네요. 어떻게 배경을 전체에 적용하죠?",
-            createdAt: "2025-08-01T09:30:00",
-            isAnswered: true,
-            answerCount: 3,
-            category: .study,
-            user: QuestionUser(
-                id: 101,
-                name: "서하",
-                email: "seoha@example.com",
-                role: false
-            ),
-            imageUrls: [
-                "https://example.com/image/question1_1.png"
-            ]
-        ),
-        QuestionList(
-            id: 2,
-            title: "Swift 네이밍 관련 질문 있어요",
-            content: "프로퍼티 이름을 카멜케이스로 짓는 게 맞는 건가요? 코딩 컨벤션에 대해 궁금합니다.",
-            createdAt: "2025-07-30T14:20:00",
-            isAnswered: false,
-            answerCount: 0,
-            category: .free,
-            user: QuestionUser(
-                id: 102,
-                name: "지민",
-                email: "jimin@mail.com",
-                role: false
-            ),
-            imageUrls: nil
-        ),
-        QuestionList(
-            id: 3,
-            title: "ViewModel에서 API 호출 시점 질문",
-            content: "onAppear에서 fetch를 해도 될까요? 아니면 init에서 하는 편이 더 나을까요?",
-            createdAt: "2025-07-28T18:45:00",
-            isAnswered: true,
-            answerCount: 5,
-            category: .study,
-            user: QuestionUser(
-                id: 103,
-                name: "영우",
-                email: "youngwoo@worlds.io",
-                role: true
-            ),
-            imageUrls: [
-                "https://example.com/image/question3_1.png",
-                "https://example.com/image/question3_2.png"
-            ]
-        ),
-        QuestionList(
-            id: 4,
-            title: "자유게시판에 글 쓰는 연습입니다",
-            content: "이 게시판은 테스트용으로 마음껏 글 올려도 되나요?",
-            createdAt: "2025-07-26T16:00:00",
-            isAnswered: false,
-            answerCount: 1,
-            category: .free,
-            user: QuestionUser(
-                id: 104,
-                name: "민준",
-                email: "minjun@domain.com",
-                role: false
-            ),
-            imageUrls: nil
-        ),
-        QuestionList(
-            id: 5,
-            title: "iOS NavigationLink 디버깅 도움 요청합니다",
-            content: "탭 했을 때 화면이 안 넘어가거나 이상한 화면이 뜰 때, 디버깅 방법 추천해주실 분~?",
-            createdAt: "2025-07-25T22:10:00",
-            isAnswered: true,
-            answerCount: 2,
-            category: .study,
-            user: QuestionUser(
-                id: 105,
-                name: "지원",
-                email: "jiwon@sample.com",
-                role: true
-            ),
-            imageUrls: [
-                "https://example.com/image/question5_1.png"
-            ]
-        )
-    ]
-
+    var questions: [QuestionList]
     
     var body: some View {
         ZStack {
@@ -110,7 +19,7 @@ struct MyQuestionView: View {
                 .ignoresSafeArea()
             ScrollView {
                 VStack(spacing: 18) {
-                    ForEach(dummyQuestionList) { question in
+                    ForEach(questions) { question in
                         NavigationLink(destination: QuestionDetailView(questionId: question.id, viewModel: QuestionViewModel())
                             .environmentObject(CommentViewModel())) {
                                 QuestionCard(question: question)

--- a/worlds-fe-v20/Views/MyPage/UserInfoCardView.swift
+++ b/worlds-fe-v20/Views/MyPage/UserInfoCardView.swift
@@ -8,6 +8,8 @@
 import SwiftUI
 
 struct UserInfoCardView: View {
+    var userInfo: User?
+    
     var body: some View {
         VStack {
             ZStack(alignment: .top) {
@@ -35,7 +37,11 @@ struct UserInfoCardView: View {
                     
                     Spacer()
                     
-                    Text("김멘티")
+                    if let userInfo = userInfo {
+                        Text("\(userInfo.userName)")
+                    } else {
+                        Text("알 수 없음")
+                    }
                 }
                 .padding(.bottom, 8)
                 
@@ -44,7 +50,11 @@ struct UserInfoCardView: View {
                     
                     Spacer()
                     
-                    Text("nnnn@n.com")
+                    if let userInfo = userInfo {
+                        Text("\(userInfo.userEmail)")
+                    } else {
+                        Text("알 수 없음")
+                    }
                 }
                 .padding(.bottom, 8)
                 
@@ -68,6 +78,6 @@ struct UserInfoCardView: View {
     }
 }
 
-#Preview {
-    UserInfoCardView()
-}
+//#Preview {
+//    UserInfoCardView()
+//}

--- a/worlds-fe-v20/Views/MyPage/UserInfoCardView.swift
+++ b/worlds-fe-v20/Views/MyPage/UserInfoCardView.swift
@@ -1,0 +1,73 @@
+//
+//  UserInfoCardView.swift
+//  worlds-fe-v20
+//
+//  Created by seohuibaek on 8/1/25.
+//
+
+import SwiftUI
+
+struct UserInfoCardView: View {
+    var body: some View {
+        VStack {
+            ZStack(alignment: .top) {
+                Rectangle()
+                    .fill(Color.mainws)
+                    .frame(height: 100)
+                    .frame(maxWidth: .infinity)
+                
+                ZStack {
+                    Circle()
+                        .fill(.white)
+                        .frame(width: 100, height: 100)
+                    
+                    Image("mentee")
+                        .resizable()
+                        .scaledToFit()
+                        .frame(width: 100, height: 100)
+                }
+                .padding(.top, 50)
+            }
+            
+            VStack(alignment: .leading) {
+                HStack {
+                    Text("이름")
+                    
+                    Spacer()
+                    
+                    Text("김멘티")
+                }
+                .padding(.bottom, 8)
+                
+                HStack {
+                    Text("이메일")
+                    
+                    Spacer()
+                    
+                    Text("nnnn@n.com")
+                }
+                .padding(.bottom, 8)
+                
+                HStack {
+                    Text("비밀번호")
+                    
+                    Spacer()
+                    
+                    Button {
+                        
+                    } label: {
+                        Text("비밀번호 재설정")
+                    }
+
+                }
+                .padding(.bottom, 16)
+            }
+            .padding(.horizontal, 16)
+        }
+        .background(Color.backgroundws)
+    }
+}
+
+#Preview {
+    UserInfoCardView()
+}

--- a/worlds-fe-v20/Views/OCR/OCRCameraView.swift
+++ b/worlds-fe-v20/Views/OCR/OCRCameraView.swift
@@ -28,124 +28,122 @@ struct OCRCameraView: View {
     @StateObject private var ocrViewModel = OCRViewModel()
     
     var body: some View {
-        NavigationStack {
-            ZStack {
-                CameraPreview(
-                    cameraPosition: $cameraPosition,
-                    cameraController: $cameraController,
-                    onPhotoCaptured: { image in
-                        print("onPhotoCaptured 호출, image: \(String(describing: image))")
-                        DispatchQueue.main.async {
-                            selectedImage = image
-                        }
+        ZStack {
+            CameraPreview(
+                cameraPosition: $cameraPosition,
+                cameraController: $cameraController,
+                onPhotoCaptured: { image in
+                    print("onPhotoCaptured 호출, image: \(String(describing: image))")
+                    DispatchQueue.main.async {
+                        selectedImage = image
                     }
-                )
-                .cornerRadius(32)
-                .padding(.horizontal)
-                .padding(.top, 10)
+                }
+            )
+            .cornerRadius(32)
+            .padding(.horizontal)
+            .padding(.top, 10)
+            
+            VStack {
                 
-                VStack {
+                Spacer()
+                
+                HStack {
+                    Spacer()
+                    
+                    Button {
+                        showingPhotoLibrary = true
+                    } label: {
+                        Image(systemName: "photo.on.rectangle")
+                            .resizable()
+                            .scaledToFit()
+                            .frame(width: 30, height: 30)
+                            .foregroundColor(.mainws)
+                            .padding()
+                            .background(.ultraThinMaterial)
+                            .clipShape(Circle())
+                    }
                     
                     Spacer()
-
-                    HStack {
-                        Spacer()
-                        
-                        Button {
-                            showingPhotoLibrary = true
-                        } label: {
-                            Image(systemName: "photo.on.rectangle")
-                                .resizable()
-                                .scaledToFit()
-                                .frame(width: 30, height: 30)
-                                .foregroundColor(.mainws)
-                                .padding()
-                                .background(.ultraThinMaterial)
-                                .clipShape(Circle())
-                        }
-                        
-                        Spacer()
-                        
-                        // 사진 촬영 버튼
-                        Button {
-                            print("촬영 버튼 클릭됨")
-                            cameraController?.capturePhoto()
-                        } label: {
-                            Circle()
-                                .fill(.white)
-                                .frame(width: 80, height: 80)
-                                .overlay(
-                                    Circle()
-                                        .stroke(.mainws, lineWidth: 4)
-                                        .frame(width: 70, height: 70)
-                                )
-                        }
-                        
-                        Spacer()
-                        
-                        // 카메라 전환 버튼
-                        Button {
-                            cameraPosition = (cameraPosition == .back) ? .front : .back
-                        } label: {
-                            Image(systemName: "arrow.triangle.2.circlepath.camera")
-                                .resizable()
-                                .scaledToFit()
-                                .frame(width: 30, height: 30)
-                                .foregroundColor(.mainws)
-                                .padding()
-                                .background(.ultraThinMaterial)
-                                .clipShape(Circle())
-                        }
-                        
-                        Spacer()
-                    }
-                }
-                .padding()
-            }
-            .navigationTitle("OCR")
-            .navigationBarTitleDisplayMode(.inline)
-            .navigationBarBackButtonHidden(true)
-            .toolbar {
-                ToolbarItem(placement: .navigationBarLeading) {
+                    
+                    // 사진 촬영 버튼
                     Button {
-                        // dismiss()
+                        print("촬영 버튼 클릭됨")
+                        cameraController?.capturePhoto()
                     } label: {
-                        Image(systemName: "chevron.left")
+                        Circle()
+                            .fill(.white)
+                            .frame(width: 80, height: 80)
+                            .overlay(
+                                Circle()
+                                    .stroke(.mainws, lineWidth: 4)
+                                    .frame(width: 70, height: 70)
+                            )
+                    }
+                    
+                    Spacer()
+                    
+                    // 카메라 전환 버튼
+                    Button {
+                        cameraPosition = (cameraPosition == .back) ? .front : .back
+                    } label: {
+                        Image(systemName: "arrow.triangle.2.circlepath.camera")
+                            .resizable()
+                            .scaledToFit()
+                            .frame(width: 30, height: 30)
                             .foregroundColor(.mainws)
-                            .font(.system(size: 18, weight: .semibold))
+                            .padding()
+                            .background(.ultraThinMaterial)
+                            .clipShape(Circle())
                     }
+                    
+                    Spacer()
                 }
             }
-            // 사진 라이브러리에서 이미지 선택 시 표시되는 시트
-            .sheet(isPresented: $showingPhotoLibrary) {
-                ImagePreview(selectedImage: $selectedImage)
-            }
-            // 이미지 선택 시 크롭 뷰로 네비게이션
-            .navigationDestination(isPresented: Binding(
-                get: { selectedImage != nil },
-                set: { if !$0 { selectedImage = nil } }
-            )) {
-                if let image = selectedImage {
-                    OCRImageResizingView(originalImage: image) { cropped in
-                        croppedImage = cropped
-                        selectedImage = nil
-                        showingResultView = true
-                        // 새로운 OCR 세션 시작 시 Summary 데이터 초기화
-                        ocrViewModel.resetSummaryData()
-                    }
+            .padding()
+        }
+        .navigationTitle("OCR")
+        .navigationBarTitleDisplayMode(.inline)
+        .navigationBarBackButtonHidden(true)
+        .toolbar {
+            ToolbarItem(placement: .navigationBarLeading) {
+                Button {
+                    // dismiss()
+                } label: {
+                    Image(systemName: "chevron.left")
+                        .foregroundColor(.mainws)
+                        .font(.system(size: 18, weight: .semibold))
                 }
             }
-            // 크롭된 이미지 결과 뷰로 네비게이션
-            .navigationDestination(isPresented: $showingResultView) {
-                if let image = croppedImage {
-                    OCRResultView(selectedImage: image)
-                        .environmentObject(ocrViewModel)
+        }
+        // 사진 라이브러리에서 이미지 선택 시 표시되는 시트
+        .sheet(isPresented: $showingPhotoLibrary) {
+            ImagePreview(selectedImage: $selectedImage)
+        }
+        // 이미지 선택 시 크롭 뷰로 네비게이션
+        .navigationDestination(isPresented: Binding(
+            get: { selectedImage != nil },
+            set: { if !$0 { selectedImage = nil } }
+        )) {
+            if let image = selectedImage {
+                OCRImageResizingView(originalImage: image) { cropped in
+                    croppedImage = cropped
+                    selectedImage = nil
+                    showingResultView = true
+                    // 새로운 OCR 세션 시작 시 Summary 데이터 초기화
+                    ocrViewModel.resetSummaryData()
                 }
             }
-            // 뷰가 나타날 때 카메라 권한 요청
-            .onAppear {
-                cameraController?.requestCameraPermission()
+        }
+        // 크롭된 이미지 결과 뷰로 네비게이션
+        .navigationDestination(isPresented: $showingResultView) {
+            if let image = croppedImage {
+                OCRResultView(selectedImage: image)
+                    .environmentObject(ocrViewModel)
             }
+        }
+        // 뷰가 나타날 때 카메라 권한 요청
+        .onAppear {
+            cameraController?.requestCameraPermission()
         }
     }
 }

--- a/worlds-fe-v20/Views/Tabbar/TabbarView.swift
+++ b/worlds-fe-v20/Views/Tabbar/TabbarView.swift
@@ -9,38 +9,40 @@ import SwiftUI
 
 struct TabbarView: View {
     var body: some View {
-        TabView {
-            MainView(viewModel: MainViewModel())
-                .tabItem {
-                    Image(systemName: "house")
-                    Text("Home")
-                }
-            
-            QuestionView(viewModel: QuestionViewModel())
-                .tabItem {
-                    Image(systemName: "questionmark.circle")
-                    Text("Question")
-                }
-            
-            OCRCameraView()
-                .tabItem {
-                    Image(systemName: "camera")
-                    Text("OCR")
-                }
-            
-            // 채팅
-            //ChatView()
-//                .tabItem {
-//                    Image(systemName: "message")
-//                    Text("Chat")
-//                }
-            
-            // 마이페이지
-            //MyPageView()
-//                .tabItem {
-//                    Image(systemName: "person")
-//                    Text("MyPage")
-//                }
+        NavigationStack {
+            TabView {
+                MainView(viewModel: MainViewModel())
+                    .tabItem {
+                        Image(systemName: "house")
+                        Text("Home")
+                    }
+                
+                QuestionView(viewModel: QuestionViewModel())
+                    .tabItem {
+                        Image(systemName: "questionmark.circle")
+                        Text("Question")
+                    }
+                
+                OCRCameraView()
+                    .tabItem {
+                        Image(systemName: "camera")
+                        Text("OCR")
+                    }
+                
+                // 채팅
+                //ChatView()
+//                    .tabItem {
+//                        Image(systemName: "message")
+//                        Text("Chat")
+//                    }
+                
+                // 마이페이지
+                MyPageView()
+                    .tabItem {
+                        Image(systemName: "person")
+                        Text("MyPage")
+                    }
+            }
         }
     }
 }


### PR DESCRIPTION
## 📄 작업 내용
- 마이페이지 전반적 기능 구현했습니다.
- 내가 쓴 글, 로그아웃, 회원탈퇴, 앱 버전 구현했습니다.

![Simulator Screen Recording - iPhone 16 Plus - 2025-08-05 at 11 29 52](https://github.com/user-attachments/assets/0ecf57a1-84e3-4c55-991f-60f46b469de7)

## 💬 공유사항 to 리뷰어
- QuestionList 모델에 user_role을 옵셔널처리 해두었습니다..
- 비밀번호 재설정은 현재 불가능 합니다.