### PR TITLE
[fix] 번역401에러 -> JWT 인증 헤더 추가

### DIFF
--- a/worlds-fe-v20/Services/APIService.swift
+++ b/worlds-fe-v20/Services/APIService.swift
@@ -10,358 +10,377 @@ import Alamofire
 import UIKit
 
 class APIService {
-static let shared = APIService()
+    static let shared = APIService()
 
-enum APIError: Error {
-    case missingToken
-    case invalidEndPoint
-}
-
-// baseURL은 Info.plist에서 가져옴
-private var baseURL: String {
-    guard let url = Bundle.main.object(forInfoDictionaryKey: "APIBaseURL") as? String else {
-        fatalError("APIBaseURL is not set in Info.plist")
+    enum APIError: Error {
+        case missingToken
+        case invalidEndPoint
     }
+
+    // baseURL은 Info.plist에서 가져옴
+    private var baseURL: String {
+        guard let url = Bundle.main.object(forInfoDictionaryKey: "APIBaseURL") as? String else {
+            fatalError("APIBaseURL is not set in Info.plist")
+        }
         return url
-}
-
-// JWT 토큰 가져오기
-func getToken() -> String? {
-    UserDefaults.standard.string(forKey: "accessToken")
-}
-
-//토큰이 필요한 API 호출을 위한 HTTP헤더 생성
-private func getAuthHeaders() throws -> HTTPHeaders {
-    guard let token = getToken() else {
-        throw APIError.missingToken
     }
-    return ["Authorization": "Bearer \(token)"]
-}
 
-//질문 목록 조회
-func fetchQuestions() async throws -> [QuestionList] {
-    let headers = try getAuthHeaders()
-    
-    let response = try await AF.request("\(baseURL)/questions", headers: headers)
-        .serializingDecodable([QuestionList].self)
-        .value
-    
-    return response
-}
+    // JWT 토큰 가져오기
+    func getToken() -> String? {
+        UserDefaults.standard.string(forKey: "accessToken")
+    }
 
-//질문 상세
-func fetchQuestionDetail(questionId: Int) async throws -> QuestionDetail {
-    let headers = try getAuthHeaders()
-    
-    let response = try await AF.request("\(baseURL)/questions/\(questionId)", headers: headers)
-        .serializingDecodable(QuestionDetail.self)
-        .value
-    
-    return response
-}
+    // 토큰이 필요한 API 호출을 위한 HTTP헤더 생성
+    private func getAuthHeaders() throws -> HTTPHeaders {
+        guard let token = getToken() else {
+            throw APIError.missingToken
+        }
+        return ["Authorization": "Bearer \(token)"]
+    }
 
-//질문 생성
-func createQuestion(title: String, content: String, category: String, images: [Data]? = nil) async throws -> Bool {
-    let headers = try getAuthHeaders()
-    
-    // 이미지가 있으면 multipart/form-data 전송
-    if let imagesData = images, !imagesData.isEmpty {
+    // 질문 목록 조회
+    func fetchQuestions() async throws -> [QuestionList] {
+        let headers = try getAuthHeaders()
+
+        let response = try await AF.request("\(baseURL)/questions", headers: headers)
+            .serializingDecodable([QuestionList].self)
+            .value
+
+        return response
+    }
+
+    // 질문 상세
+    func fetchQuestionDetail(questionId: Int) async throws -> QuestionDetail {
+        let headers = try getAuthHeaders()
+
+        let response = try await AF.request("\(baseURL)/questions/\(questionId)", headers: headers)
+            .serializingDecodable(QuestionDetail.self)
+            .value
+
+        return response
+    }
+
+    // 질문 상세의 첨부(썸네일)만 최소 디코딩해서 가져오기
+    func fetchQuestionAttachments(questionId: Int) async throws -> [String]? {
+        struct QuestionDetailMinimal: Decodable { let attachments: [String]? }
+        let headers = try getAuthHeaders()
+        let response = try await AF.request("\(baseURL)/questions/\(questionId)", headers: headers)
+            .validate()
+            .serializingDecodable(QuestionDetailMinimal.self)
+            .value
+        return response.attachments
+    }
+
+    // 질문 생성
+    func createQuestion(title: String, content: String, category: String, images: [Data]? = nil) async throws -> Bool {
+        let headers = try getAuthHeaders()
+
+        // 이미지가 있으면 multipart/form-data 전송
+        if let imagesData = images, !imagesData.isEmpty {
 //            print("multipart 업로드 시작")
-        let url = "\(baseURL)/questions/with-image"
-        
-        return try await withCheckedThrowingContinuation { continuation in
-            AF.upload(
-                multipartFormData: { multipartFormData in
-                    multipartFormData.append(title.data(using: .utf8)!, withName: "title")
-                    multipartFormData.append(content.data(using: .utf8)!, withName: "content")
-                    multipartFormData.append(category.data(using: .utf8)!, withName: "category")
-                    
-                    for (index, imageData) in imagesData.enumerated() {
-                        multipartFormData.append(imageData,
-                                                 withName: "images",
-                                                 fileName: "image\(index).jpg",
-                                                 mimeType: "image/jpeg")
+            let url = "\(baseURL)/questions/with-image"
+
+            return try await withCheckedThrowingContinuation { continuation in
+                AF.upload(
+                    multipartFormData: { multipartFormData in
+                        multipartFormData.append(title.data(using: .utf8)!, withName: "title")
+                        multipartFormData.append(content.data(using: .utf8)!, withName: "content")
+                        multipartFormData.append(category.data(using: .utf8)!, withName: "category")
+
+                        for (index, imageData) in imagesData.enumerated() {
+                            multipartFormData.append(
+                                imageData,
+                                withName: "images",
+                                fileName: "image\(index).jpg",
+                                mimeType: "image/jpeg"
+                            )
+                        }
+                    },
+                    to: url,
+                    method: .post,
+                    headers: headers
+                )
+                .validate()
+                .response { response in
+                    switch response.result {
+                    case .success:
+                        continuation.resume(returning: true)
+                    case .failure(let error):
+                        continuation.resume(throwing: error)
                     }
-                },
-                to: url,
+                }
+            }
+        } else {
+            let url = "\(baseURL)/questions"
+            let params: [String: Any] = [
+                "title": title,
+                "content": content,
+                "category": category
+            ]
+            let response = try await AF.request(
+                url,
                 method: .post,
+                parameters: params,
+                encoding: JSONEncoding.default,
                 headers: headers
             )
             .validate()
-            .response { response in
+            .serializingData()
+            .response
+
+            return response.error == nil
+        }
+    }
+
+    // 번역 요청 (JWT 포함, source 자동 감지 기본)
+    func translateText(text: String, source: String = "auto", target: String, completion: @escaping (String?) -> Void) {
+        let url = "\(baseURL)/translate"
+
+        let parameters: [String: Any] = [
+            "text": text,
+            "source": source,
+            "target": target
+        ]
+
+        do {
+            let headers = try getAuthHeaders() // Authorization: Bearer ...
+            AF.request(
+                url,
+                method: .post,
+                parameters: parameters,
+                encoding: JSONEncoding.default,
+                headers: headers
+            )
+            .validate()
+            .responseDecodable(of: [String: String].self) { response in
                 switch response.result {
-                case .success:
-                    continuation.resume(returning: true)
-                case .failure(let error):
-                    continuation.resume(throwing: error)
+                case .success(let data):
+                    completion(data["translated"])
+                case .failure:
+                    if let data = response.data, let serverMsg = String(data: data, encoding: .utf8) {
+                        print("❌ 번역 실패(서버 응답):", serverMsg)
+                    }
+                    completion(nil)
                 }
             }
+        } catch {
+            print("❌ 번역 실패: 토큰 없음")
+            completion(nil)
         }
-    } else {
-        let url = "\(baseURL)/questions"
-        let params: [String: Any] = [
-            "title": title,
-            "content": content,
-            "category": category
+    }
+
+    // 질문 삭제
+    func deleteQuestion(questionId: Int) async throws -> Bool {
+        let headers = try getAuthHeaders()
+
+        let response = try await AF.request("\(baseURL)/questions/\(questionId)", method: .delete, headers: headers)
+            .validate()
+            .serializingData()
+            .response
+
+        print("삭제 완료: \(response)")
+        return response.error == nil
+    }
+
+    // 질문 신고
+    func reportQuestion(
+        questionId: Int,
+        reason: ReportReason,
+        etcReason: String? = nil
+    ) async throws -> Bool {
+        let headers = try getAuthHeaders()
+        var params: [String: Any] = [
+            "reason": reason.rawValue
         ]
+        if let etc = etcReason, !etc.isEmpty {
+            params["etcReason"] = etc
+        }
+
+        let response = try await AF.request(
+            "\(baseURL)/questions/\(questionId)/report",
+            method: .post,
+            parameters: params,
+            encoding: JSONEncoding.default,
+            headers: headers
+        )
+        .validate()
+        .serializingData()
+        .response
+
+        print("신고 응답: \(response)")
+        return response.error == nil
+    }
+
+    // 댓글, 대댓글 작성
+    func postComment(content: String, questionId: Int, parentId: Int? = nil) async throws -> Bool {
+        let headers = try getAuthHeaders()
+        var params: [String: Any] = ["content": content]
+
+        let url: String
+
+        if let parentId = parentId {
+            // 대댓글인 경우
+            url = "\(baseURL)/comment/\(parentId)/reply"
+        } else {
+            // 일반 댓글인 경우
+            url = "\(baseURL)/comment/question/\(questionId)"
+        }
+
         let response = try await AF.request(
             url,
             method: .post,
             parameters: params,
             encoding: JSONEncoding.default,
-            headers: headers )
-            .validate()
-            .serializingData()
-            .response
-        
+            headers: headers
+        )
+        .validate()
+        .serializingData()
+        .response
+
         return response.error == nil
     }
-}
-    
-    
-// 번역 요청
-func translateText(text: String, source: String = "ko", target: String, completion: @escaping (String?) -> Void) {
-    let url = "\(baseURL)/translate"
-    
-    let parameters: [String: Any] = [
-        "text": text,
-        "source": source,
-        "target": target
-    ]
-    
-    AF.request(
-        url,
-        method: .post,
-        parameters: parameters,
-        encoding: JSONEncoding.default
-    )
-    .validate()
-    .responseDecodable(of: [String: String].self) { response in
-        switch response.result {
-        case .success(let data):
-            completion(data["translated"])
-        case .failure(let error):
-            print("❌ 번역 실패: \(error.localizedDescription)")
-            completion(nil)
-        }
-    }
-}
 
+    // 댓글 조회
+    func fetchComments(for questionId: Int) async throws -> [Comment] {
+        let headers = try getAuthHeaders()
 
-//질문 삭제
-func deleteQuestion(questionId: Int) async throws -> Bool {
-    let headers = try getAuthHeaders()
-    
-    let response = try await AF.request("\(baseURL)/questions/\(questionId)", method: .delete,
-                                        headers: headers)
-        .validate()
-        .serializingData()
-        .response
-    
-    print("삭제 완료: \(response)")
-    return response.error == nil
-    
-}
-
-//질문 신고
-func reportQuestion(
-    questionId: Int,
-    reason: ReportReason,
-    etcReason: String? = nil
-) async throws -> Bool {
-    let headers = try getAuthHeaders()
-    var params: [String: Any] = [
-        "reason": reason.rawValue
-    ]
-    if let etc = etcReason, !etc.isEmpty {
-        params["etcReason"] = etc
-    }
-    
-    let response = try await AF.request(
-        "\(baseURL)/questions/\(questionId)/report",
-        method: .post,
-        parameters: params,
-        encoding: JSONEncoding.default,
-        headers: headers
-    )
-        .validate()
-        .serializingData()
-        .response
-    
-    print("신고 응답: \(response)")
-    return response.error == nil
-}
-
-// 댓글, 대댓글 작성
-func postComment(content: String, questionId: Int, parentId: Int? = nil) async throws -> Bool {
-    let headers = try getAuthHeaders()
-    var params: [String: Any] = ["content": content]
-    
-    let url: String
-    
-    if let parentId = parentId {
-        // 대댓글인 경우
-        url = "\(baseURL)/comment/\(parentId)/reply"
-    } else {
-        // 일반 댓글인 경우
-        url = "\(baseURL)/comment/question/\(questionId)"
-    }
-    
-    let response = try await AF.request(
-        url,
-        method: .post,
-        parameters: params,
-        encoding: JSONEncoding.default,
-        headers: headers
-    )
-    .validate()
-    .serializingData()
-    .response
-    
-    return response.error == nil
-}
-
-// 댓글 조회
-func fetchComments(for questionId: Int) async throws -> [Comment] {
-    let headers = try getAuthHeaders()
-    
-    let response = try await AF.request(
-        "\(baseURL)/comment/question/\(questionId)",
-        headers: headers
-    )
+        let response = try await AF.request(
+            "\(baseURL)/comment/question/\(questionId)",
+            headers: headers
+        )
         .validate()
         .serializingDecodable([Comment].self)
         .value
-    
-    return response
-}
 
-// 댓글 신고
-func reportComment(commentId: Int, reason: String, etcReason: String? = nil, questionId: Int? = nil) async throws -> Bool {
-    let headers = try getAuthHeaders()
-    
-    var params: [String: Any] = [
-        "reason": reason
-    ]
-    
-    if let etcReason = etcReason {
-        params["etcReason"] = etcReason
+        return response
     }
-    
-    if let questionId = questionId {
-        params["questionId"] = questionId
+
+    // 댓글 신고
+    func reportComment(commentId: Int, reason: String, etcReason: String? = nil, questionId: Int? = nil) async throws -> Bool {
+        let headers = try getAuthHeaders()
+
+        var params: [String: Any] = [
+            "reason": reason
+        ]
+
+        if let etcReason = etcReason {
+            params["etcReason"] = etcReason
+        }
+
+        if let questionId = questionId {
+            params["questionId"] = questionId
+        }
+
+        let response = try await AF.request(
+            "\(baseURL)/comment/\(commentId)/report",
+            method: .post,
+            parameters: params,
+            encoding: JSONEncoding.default,
+            headers: headers
+        )
+        .validate()
+        .serializingData()
+        .response
+
+        return response.error == nil
     }
-    
-    let response = try await AF.request(
-        "\(baseURL)/comment/\(commentId)/report",
-        method: .post,
-        parameters: params,
-        encoding: JSONEncoding.default,
-        headers: headers
-    )
-        .validate()
-        .serializingData()
-        .response
-    
-    return response.error == nil
-}
 
-// 댓글 삭제
-func deleteComment(commentId: Int) async throws -> Bool {
-    let headers = try getAuthHeaders()
-    
-    let response = try await AF.request(
-        "\(baseURL)/comment/\(commentId)",
-        method: .delete,
-        headers: headers
-    )
-        .validate()
-        .serializingData()
-        .response
-    
-    return response.error == nil
-}
+    // 댓글 삭제
+    func deleteComment(commentId: Int) async throws -> Bool {
+        let headers = try getAuthHeaders()
 
-// 댓글 좋아요 토글
-func toggleCommentLike(commentId: Int) async throws -> CommentLike {
-    let headers = try getAuthHeaders()
-  
-    // 먼저 POST 요청 (좋아요 시도)
-    let postResponse = try await AF.request(
-        "\(baseURL)/comment/like/\(commentId)",
-        method: .post,
-        headers: headers
-    )
-        .validate()
-        .serializingData()
-        .response
-    
-    if postResponse.error == nil {
-        // 좋아요 성공 → count 다시 조회
-        let count = try await fetchLikeCount(commentId: commentId)
-        return CommentLike(id: commentId, count: count, isLiked: true)
-    } else {
-        // 이미 좋아요한 상태일 경우 → DELETE로 취소 시도
-        let deleteResponse = try await AF.request(
-            "\(baseURL)/comment/like/\(commentId)",
+        let response = try await AF.request(
+            "\(baseURL)/comment/\(commentId)",
             method: .delete,
             headers: headers
         )
+        .validate()
+        .serializingData()
+        .response
+
+        return response.error == nil
+    }
+
+    // 댓글 좋아요 토글
+    func toggleCommentLike(commentId: Int) async throws -> CommentLike {
+        let headers = try getAuthHeaders()
+
+        // 먼저 POST 요청 (좋아요 시도)
+        let postResponse = try await AF.request(
+            "\(baseURL)/comment/like/\(commentId)",
+            method: .post,
+            headers: headers
+        )
+        .validate()
+        .serializingData()
+        .response
+
+        if postResponse.error == nil {
+            // 좋아요 성공 → count 다시 조회
+            let count = try await fetchLikeCount(commentId: commentId)
+            return CommentLike(id: commentId, count: count, isLiked: true)
+        } else {
+            // 이미 좋아요한 상태일 경우 → DELETE로 취소 시도
+            let deleteResponse = try await AF.request(
+                "\(baseURL)/comment/like/\(commentId)",
+                method: .delete,
+                headers: headers
+            )
             .validate()
             .serializingData()
             .response
-      
-        if deleteResponse.error == nil {
-            // 좋아요 취소 성공 → count 다시 조회
-            let count = try await fetchLikeCount(commentId: commentId)
-            return CommentLike(id: commentId, count: count, isLiked: false)
-        } else {
-            // POST 실패 + DELETE 실패 → 에러 반환
-            throw deleteResponse.error!
+
+            if deleteResponse.error == nil {
+                // 좋아요 취소 성공 → count 다시 조회
+                let count = try await fetchLikeCount(commentId: commentId)
+                return CommentLike(id: commentId, count: count, isLiked: false)
+            } else {
+                // POST 실패 + DELETE 실패 → 에러 반환
+                throw deleteResponse.error!
+            }
         }
     }
-}
 
-// 댓글 좋아요 수 + isLiked 여부 조회(백엔드를 따로따로 만들어서 둘을 합쳐 쓰기 위한 함수)
-// 1. fetchLikeCount()를 호출해서 해당 댓글에 총 몇 개의 좋아요가 있는지 가져오고
-// 2. fetchIsLiked()를 호출해서 내가 좋아요를 눌렀는지 서버에서 확인한 뒤
-// 3. 그 정보를 바탕으로 CommentLike 구조체 생성해서 반환
-func fetchCommentLike(commentId: Int) async throws -> CommentLike {
-    let headers = try getAuthHeaders()
-    let count = try await fetchLikeCount(commentId: commentId)
-    let isLiked = try await fetchIsLiked(commentId: commentId)
-    
-    return CommentLike(id: commentId, count: count, isLiked: isLiked)
-}
+    // 댓글 좋아요 수 + isLiked 여부 조회(백엔드를 따로따로 만들어서 둘을 합쳐 쓰기 위한 함수)
+    // 1. fetchLikeCount()를 호출해서 해당 댓글에 총 몇 개의 좋아요가 있는지 가져오고
+    // 2. fetchIsLiked()를 호출해서 내가 좋아요를 눌렀는지 서버에서 확인한 뒤
+    // 3. 그 정보를 바탕으로 CommentLike 구조체 생성해서 반환
+    func fetchCommentLike(commentId: Int) async throws -> CommentLike {
+        let headers = try getAuthHeaders()
+        let count = try await fetchLikeCount(commentId: commentId)
+        let isLiked = try await fetchIsLiked(commentId: commentId)
 
-// 좋아요 수
-func fetchLikeCount(commentId: Int) async throws -> Int {
-    let headers = try getAuthHeaders()
+        return CommentLike(id: commentId, count: count, isLiked: isLiked)
+    }
 
-    let count = try await AF.request(
-        "\(baseURL)/comment/like/\(commentId)/count",
-        headers: headers
-    )
+    // 좋아요 수
+    func fetchLikeCount(commentId: Int) async throws -> Int {
+        let headers = try getAuthHeaders()
+
+        let count = try await AF.request(
+            "\(baseURL)/comment/like/\(commentId)/count",
+            headers: headers
+        )
         .validate()
         .serializingDecodable(Int.self)
         .value
-    
-    return count
-}
 
-// 유저가 좋아요를 눌렀는지 여부
-func fetchIsLiked(commentId: Int) async throws -> Bool {
-    let headers = try getAuthHeaders()
-  
-    let response = try await AF.request(
-        "\(baseURL)/comment/like/\(commentId)/isLiked",
-        method: .get,
-        headers: headers
-    )
+        return count
+    }
+
+    // 유저가 좋아요를 눌렀는지 여부
+    func fetchIsLiked(commentId: Int) async throws -> Bool {
+        let headers = try getAuthHeaders()
+
+        let response = try await AF.request(
+            "\(baseURL)/comment/like/\(commentId)/isLiked",
+            method: .get,
+            headers: headers
+        )
         .validate()
         .serializingDecodable(Bool.self)
         .value
-    
-    return response
-}
+
+        return response
+    }
 }

--- a/worlds-fe-v20/Views/QuestionDetailView.swift
+++ b/worlds-fe-v20/Views/QuestionDetailView.swift
@@ -11,35 +11,42 @@ import SwiftUI
 
 struct QuestionDetailView: View {
     let questionId: Int
-    
+
     @State private var questionDetail: QuestionDetail?
     @State private var goToCreateAnswerView = false
     @StateObject private var commentVM = CommentViewModel()
-    
+
     @State private var showOptions = false
     @State private var showReportReasons = false
     @ObservedObject var viewModel: QuestionViewModel
     @Environment(\.presentationMode) var presentationMode
     @Environment(\.dismiss) var dismiss
-    
+
     @FocusState private var isTextFieldFocused: Bool
-    
+
     @State private var translatedTitle: String?
     @State private var translatedContent: String?
-    
+
+    @State private var isImageViewerPresented: Bool = false
+    @State private var selectedImageURL: URL? = nil
+    @State private var zoomScale: CGFloat = 1.0
+    @State private var lastZoomScale: CGFloat = 1.0
+    @State private var dragOffset: CGSize = .zero
+    @State private var accumulatedOffset: CGSize = .zero
+
     let reportReasons: [(label: String, value: ReportReason)] = [
         ("비속어", .offensive),
         ("음란", .sexual),
         ("광고", .ad),
         ("기타", .etc)
     ]
-    
+
     let badgeColorMap: [String: Color] = [
         "학습": .mainws,
         "자유": .purple,
         "전체": .gray
     ]
-    
+
     var body: some View {
         VStack(spacing: 0) {
             if let question = questionDetail {
@@ -54,9 +61,9 @@ struct QuestionDetailView: View {
                                 .padding(.vertical, 8)
                                 .background(badgeColorMap[question.category.displayName] ?? .gray)
                                 .cornerRadius(16)
-                            
+
                             Spacer()
-                            
+
                             Button {
                                 showOptions = true
                             } label: {
@@ -69,7 +76,7 @@ struct QuestionDetailView: View {
                         .padding(.horizontal)
                         .padding(.top, 10)
                         .padding(.bottom, 12)
-                        
+
                         HStack(spacing: 10) {
                             Image(systemName: "person.circle.fill")
                                 .resizable()
@@ -86,7 +93,7 @@ struct QuestionDetailView: View {
                             Spacer()
                         }
                         .padding(.horizontal)
-                        
+
                         Text(translatedTitle ?? question.title)
                             .font(.title)
                             .fontWeight(.bold)
@@ -99,7 +106,7 @@ struct QuestionDetailView: View {
                             .padding(.top, 18)
                             .padding(.horizontal)
                             .frame(maxWidth: .infinity, minHeight: 150, alignment: .leading)
-                        
+
                         if let imageUrls = question.imageUrls, !imageUrls.isEmpty {
                             ScrollView(.horizontal, showsIndicators: false) {
                                 HStack(spacing: 12) {
@@ -123,6 +130,10 @@ struct QuestionDetailView: View {
                                                     EmptyView()
                                                 }
                                             }
+                                            .onTapGesture {
+                                                selectedImageURL = url
+                                                isImageViewerPresented = true
+                                            }
                                         }
                                     }
                                 }
@@ -130,25 +141,26 @@ struct QuestionDetailView: View {
                                 .padding(.top, 8)
                             }
                         }
-                        
+
                         Button("번역하기") {
                             guard let question = questionDetail else { return }
-                            
+
                             let targetLang = Locale.preferredLanguages.first?.components(separatedBy: "-").first ?? "en"
-                            
+
                             if targetLang == "ko" {
                                 self.translatedTitle = question.title
                                 self.translatedContent = question.content
                                 return
                             }
-                            
-                            APIService().translateText(text: question.title, target: targetLang) { translated in
+
+                            // ✅ JWT 헤더 포함 + source 자동감지로 호출
+                            APIService.shared.translateText(text: question.title, source: "auto", target: targetLang) { translated in
                                 DispatchQueue.main.async {
                                     self.translatedTitle = translated
                                 }
                             }
-                            
-                            APIService().translateText(text: question.content, target: targetLang) { translated in
+
+                            APIService.shared.translateText(text: question.content, source: "auto", target: targetLang) { translated in
                                 DispatchQueue.main.async {
                                     self.translatedContent = translated
                                 }
@@ -158,18 +170,18 @@ struct QuestionDetailView: View {
                         .foregroundColor(.blue)
                         .padding(.horizontal)
                         .padding(.top, 14)
-                        
+
                         Color.gray.opacity(0.1)
                             .frame(height: 13)
                             .frame(maxWidth: .infinity)
                             .padding(.horizontal, -20)
-                        
+
                         Text("댓글 \(commentVM.comments.count)개")
                             .font(.subheadline)
                             .bold()
                             .padding(.top, 12)
                             .padding(.horizontal)
-                        
+
                         VStack(alignment: .leading, spacing: 15) {
                             if commentVM.comments.isEmpty {
                                 Text("아직 답변이 없습니다.")
@@ -200,42 +212,130 @@ struct QuestionDetailView: View {
                     }
                 )
                 Divider()
-                
+
                 // 댓글 입력창 (항상 하단 고정)
-                    .safeAreaInset(edge: .bottom) {
-                        HStack {
-                            TextField("댓글을 입력하세요",
-                                      text: commentVM.replyingTo == nil ? $commentVM.newComment : $commentVM.replyContent)
-                            .padding(12)
-                            .background(Color.white)
-                            .overlay(
-                                RoundedRectangle(cornerRadius: 10)
-                                    .stroke(Color.mainws, lineWidth: 1)
-                            )
-                            .focused($isTextFieldFocused)
-                            
-                            Button(action: {
-                                Task {
-                                    await commentVM.submitComment(
-                                        for: questionId,
-                                        parentId: commentVM.replyingTo // nil이면 일반 댓글
-                                    )
-                                    isTextFieldFocused = false
-                                    
-                                }
-                            }) {
-                                Text("등록")
-                                    .frame(minWidth: 60)
-                                    .padding(.vertical, 12)
-                                    .background(Color.mainws)
-                                    .foregroundColor(.white)
-                                    .clipShape(RoundedRectangle(cornerRadius: 10))
-                            }
-                            .padding(.leading, 8)
-                        }
-                        .padding()
+                .safeAreaInset(edge: .bottom) {
+                    HStack {
+                        TextField(
+                            "댓글을 입력하세요",
+                            text: commentVM.replyingTo == nil ? $commentVM.newComment : $commentVM.replyContent
+                        )
+                        .padding(12)
                         .background(Color.white)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 10)
+                                .stroke(Color.mainws, lineWidth: 1)
+                        )
+                        .focused($isTextFieldFocused)
+
+                        Button(action: {
+                            Task {
+                                await commentVM.submitComment(
+                                    for: questionId,
+                                    parentId: commentVM.replyingTo // nil이면 일반 댓글
+                                )
+                                isTextFieldFocused = false
+                            }
+                        }) {
+                            Text("등록")
+                                .frame(minWidth: 60)
+                                .padding(.vertical, 12)
+                                .background(Color.mainws)
+                                .foregroundColor(.white)
+                                .clipShape(RoundedRectangle(cornerRadius: 10))
+                        }
+                        .padding(.leading, 8)
                     }
+                    .padding()
+                    .background(Color.white)
+                }
+                .fullScreenCover(isPresented: $isImageViewerPresented) {
+                    ZStack {
+                        Color.black.ignoresSafeArea()
+                        if let url = selectedImageURL {
+                            AsyncImage(url: url) { phase in
+                                switch phase {
+                                case .empty:
+                                    ProgressView()
+                                case .success(let image):
+                                    GeometryReader { proxy in
+                                        let magnify = MagnificationGesture()
+                                            .onChanged { value in
+                                                // value is relative to the start of this gesture
+                                                let relative = value / lastZoomScale
+                                                var newScale = zoomScale * relative
+                                                newScale = min(max(newScale, 1.0), 4.0) // clamp 1x ~ 4x
+                                                zoomScale = newScale
+                                                lastZoomScale = value
+                                            }
+                                            .onEnded { _ in
+                                                lastZoomScale = 1.0
+                                            }
+                                        let drag = DragGesture()
+                                            .onChanged { gesture in
+                                                guard zoomScale > 1.0 else { return }
+                                                dragOffset = CGSize(
+                                                    width: accumulatedOffset.width + gesture.translation.width,
+                                                    height: accumulatedOffset.height + gesture.translation.height
+                                                )
+                                            }
+                                            .onEnded { _ in
+                                                accumulatedOffset = dragOffset
+                                            }
+
+                                        image
+                                            .resizable()
+                                            .scaledToFit()
+                                            .scaleEffect(zoomScale)
+                                            .offset(dragOffset)
+                                            .frame(width: proxy.size.width, height: proxy.size.height)
+                                            .background(Color.black)
+                                            .ignoresSafeArea()
+                                            .gesture(drag)
+                                            .gesture(magnify)
+                                            .onTapGesture(count: 2) {
+                                                if zoomScale > 1.0 {
+                                                    // reset
+                                                    zoomScale = 1.0
+                                                    dragOffset = .zero
+                                                    accumulatedOffset = .zero
+                                                } else {
+                                                    zoomScale = 2.0
+                                                }
+                                            }
+                                    }
+                                case .failure:
+                                    VStack(spacing: 12) {
+                                        Image(systemName: "xmark.octagon")
+                                            .foregroundColor(.red)
+                                        Text("이미지를 불러오지 못했습니다")
+                                            .foregroundColor(.white)
+                                    }
+                                @unknown default:
+                                    EmptyView()
+                                }
+                            }
+                        }
+                        // 닫기 버튼
+                        VStack {
+                            HStack {
+                                Spacer()
+                                Button(action: {
+                                    isImageViewerPresented = false
+                                    zoomScale = 1.0
+                                    dragOffset = .zero
+                                    accumulatedOffset = .zero
+                                }) {
+                                    Image(systemName: "xmark.circle.fill")
+                                        .font(.system(size: 28, weight: .bold))
+                                        .foregroundColor(.white.opacity(0.9))
+                                        .padding(12)
+                                }
+                            }
+                            Spacer()
+                        }
+                    }
+                }
             } else {
                 ProgressView()
             }
@@ -244,7 +344,7 @@ struct QuestionDetailView: View {
             Task {
                 // 댓글 데이터 초기화 - @StateObject는 재사용되므로 필요
                 commentVM.resetComments()
-                
+
                 await viewModel.fetchQuestionDetail(questionId: questionId)
                 self.questionDetail = viewModel.selectedQuestion
                 await commentVM.fetchComments(for: questionId)
@@ -268,12 +368,15 @@ struct QuestionDetailView: View {
             Button("신고") {
                 showReportReasons = true
             }
-            Button("삭제", role: .destructive) {
-                Task {
-                    try await viewModel.deleteQuestion(id: questionId)
-                    await MainActor.run {
-                        viewModel.questions.removeAll { $0.id == questionId }
-                        presentationMode.wrappedValue.dismiss()
+            let currentUserId = UserDefaults.standard.integer(forKey: "userId")
+            if (questionDetail?.user.id ?? -1) == currentUserId {
+                Button("삭제", role: .destructive) {
+                    Task {
+                        try await viewModel.deleteQuestion(id: questionId)
+                        await MainActor.run {
+                            viewModel.questions.removeAll { $0.id == questionId }
+                            presentationMode.wrappedValue.dismiss()
+                        }
                     }
                 }
             }
@@ -290,7 +393,7 @@ struct QuestionDetailView: View {
             Button("취소", role: .cancel) {}
         }
     }
-    
+
     // 날짜 포맷터
     func formatDate(_ dateStr: String) -> String {
         let inputFormatter = ISO8601DateFormatter()
@@ -302,3 +405,4 @@ struct QuestionDetailView: View {
         return dateStr.prefix(10) + " " + dateStr.dropFirst(11).prefix(5)
     }
 }
+


### PR DESCRIPTION
## 📄 작업 내용

- 구글 번역 API 프론트에선 작동 잘되다가 백엔드까지로 연결하니까 번역 안됨 이슈 발생
-> 백엔드 @UseGuards(JwtAuthGuard)로 /translate가 인증 필요인데 APIService.translateText 호출은 헤더 없이 요청했기 때문에 401(403) 오류 뜬것..

- 번역 요청 시 JWT 인증 헤더 추가
- 번역 요청 파라미터의 기본 `source`를 `"auto"`로 변경, 실제 호출부에서도 `"auto"`로 전달하도록 수정
- 번역 호출 -> `APIService.shared` 사용으로 통일 
   APIService().translateText → **APIService.shared.translateText**로 통일

<img width="250" height="470" alt="image" src="https://github.com/user-attachments/assets/924b542f-d5a9-46d9-8989-d0c88a2ede17" />

## 💻 주요 코드 설명

`APIService.swift`
- JWT 포함 + auto 기본값으로 변경
```swift
func translateText(text: String, source: String = "auto", target: String, completion: @escaping (String?) -> Void) {
    let url = "\(baseURL)/translate"

    let parameters: [String: Any] = [
        "text": text,
        "source": source,
        "target": target
    ]

    do {
        let headers = try getAuthHeaders() // Authorization: Bearer <token>
        AF.request(
            url,
            method: .post,
            parameters: parameters,
            encoding: JSONEncoding.default,
            headers: headers
        )
        .validate()
        .responseDecodable(of: [String: String].self) { response in
            switch response.result {
            case .success(let data):
                completion(data["translated"])
            case .failure:
                if let data = response.data,
                   let serverMsg = String(data: data, encoding: .utf8) {
                    print("❌ 번역 실패(서버 응답):", serverMsg)
                }
                completion(nil)
            }
        }
    } catch {
        print("❌ 번역 실패: 토큰 없음")
        completion(nil)
    }
}
```

## 💬 공유사항 to 리뷰어

- 서버에서 "auto"일 때 source 필드를 요청 바디에서 제거


