### PR TITLE
[fix] 댓글 삭제하기 기능 에러 수정

### DIFF
--- a/worlds-fe-v20.xcodeproj/project.pbxproj
+++ b/worlds-fe-v20.xcodeproj/project.pbxproj
@@ -307,7 +307,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0.3;
-				PRODUCT_BUNDLE_IDENTIFIER = "org.kibwa.worlds-fe-v20";
+				PRODUCT_BUNDLE_IDENTIFIER = "org.kibwa.lde.worlds-fe-v20";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
@@ -346,7 +346,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0.3;
-				PRODUCT_BUNDLE_IDENTIFIER = "org.kibwa.worlds-fe-v20";
+				PRODUCT_BUNDLE_IDENTIFIER = "org.kibwa.lde.worlds-fe-v20";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;

--- a/worlds-fe-v20/Info.plist
+++ b/worlds-fe-v20/Info.plist
@@ -28,18 +28,8 @@
 	<string>$(API_SIGNUP_URL)</string>
 	<key>APIUserInfoURL</key>
 	<string>$(API_USER_INFO_URL)</string>
-	<key>APIOCRURL</key>
-	<string>$(API_OCR_URL)</string>
-	<key>APIOCRSolutionURL</key>
-	<string>$(API_OCR_SOLUTION_URL)</string>
-	<key>APIMyQuestionURL</key>
-	<string>$(API_MY_QUESTION_URL)</string>
-	<key>APIDeleteAccountURL</key>
-	<string>$(API_DELETE_ACCOUNT_URL)</string>
 	<key>CFBundleIconName</key>
 	<string>AppIcon</string>
-	<key>ITSAppUsesNonExemptEncryption</key>
-	<false/>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>

--- a/worlds-fe-v20/Models/Comment.swift
+++ b/worlds-fe-v20/Models/Comment.swift
@@ -13,6 +13,7 @@ struct Comment: Codable, Identifiable {
     let createdAt: String
     let questionId: Int
     let user: User
+    let deleted: Bool?
     let parentId: Int?
     
     struct User: Codable {

--- a/worlds-fe-v20/Services/APIService.swift
+++ b/worlds-fe-v20/Services/APIService.swift
@@ -267,20 +267,24 @@ func reportComment(commentId: Int, reason: String, etcReason: String? = nil, que
 }
 
 // 댓글 삭제
-func deleteComment(commentId: Int) async throws -> Bool {
-    let headers = try getAuthHeaders()
-    
-    let response = try await AF.request(
-        "\(baseURL)/comment/\(commentId)",
-        method: .delete,
-        headers: headers
-    )
+    func deleteComment(commentId: Int) async throws -> Bool {
+        let headers = try getAuthHeaders()
+
+        let dataResponse = try await AF.request(
+            "\(baseURL)/comment/\(commentId)",
+            method: .delete,
+            headers: headers
+        )
         .validate()
         .serializingData()
         .response
-    
-    return response.error == nil
-}
+
+        let status = dataResponse.response?.statusCode ?? -1
+        let bodyString = String(data: dataResponse.data ?? Data(), encoding: .utf8) ?? "<no body>"
+        print("🗑️ DELETE /comment/\(commentId) status=\(status) body=\(bodyString)")
+
+        return (200...299).contains(status)
+    }
 
 // 댓글 좋아요 토글
 func toggleCommentLike(commentId: Int) async throws -> CommentLike {

--- a/worlds-fe-v20/ViewModels/ChatViewModel.swift
+++ b/worlds-fe-v20/ViewModels/ChatViewModel.swift
@@ -14,11 +14,32 @@ class ChatViewModel: ObservableObject {
     // 날짜별로 메시지 그룹화
     var groupedMessages: [String: [Message]] {
         let grouped = Dictionary(grouping: messages) { message in
-            formatDateOnly(from: message.createdAt)
+            let dateKey = formatDateOnly(from: message.createdAt)
+            return dateKey.isEmpty ? "unknown date" : dateKey
         }
         return grouped.mapValues { group in
-            group.sorted(by: { $0.createdAt < $1.createdAt })
+            group.sorted { 
+                guard let date0 = parseISO8601($0.createdAt), let date1 = parseISO8601($1.createdAt) else {
+                    return $0.createdAt < $1.createdAt
+                }
+                return date0 < date1
+            }
         }
+    }
+
+    private let pageSize = 20
+    private var latestPageSkip: Int = 0
+    private var discoveredTotal: Int?
+
+    private func parseISO8601(_ s: String) -> Date? {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let date = formatter.date(from: s) {
+            return date
+        }
+        // fallback without fractional seconds
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter.date(from: s)
     }
 
     private func formatDateOnly(from dateString: String) -> String {
@@ -36,11 +57,8 @@ class ChatViewModel: ObservableObject {
     func connectAndJoin(chatId: Int) {
         SocketService.shared.connect()
         SocketService.shared.joinRoom(roomId: chatId)
-        SocketService.shared.onReceiveMessage { [weak self] message in
-            DispatchQueue.main.async {
-                self?.messages.append(message)
-            }
-        }
+        // 리스너 등록 (로그 포함)
+        onReceiveMessage()
     }
     
     func sendMessage(chatId: Int, userId: Int, content: String) {
@@ -89,19 +107,112 @@ class ChatViewModel: ObservableObject {
             }
         }
     }
-    
-    func fetchMessages(for roomId: Int) {
-        SocketService.shared.fetchMessages(roomId: roomId) { messagesArray in
-            guard let messagesArray = messagesArray else { return }
-            
+
+    func seed(initialMessages: [Message]) {
+        DispatchQueue.main.async {
+            let existingIDs = Set(self.messages.map { $0.id })
+            let newMessages = initialMessages.filter { !existingIDs.contains($0.id) }
+            self.messages.append(contentsOf: newMessages)
+            self.messages.sort {
+                guard let d0 = self.parseISO8601($0.createdAt), let d1 = self.parseISO8601($1.createdAt) else {
+                    return $0.createdAt < $1.createdAt
+                }
+                return d0 < d1
+            }
+        }
+    }
+
+    func findLastPage(roomId: Int, completion: @escaping (Int) -> Void) {
+        var skip = 0
+        func fetchPage() {
+            SocketService.shared.fetchMessages(roomId: roomId, take: pageSize, skip: skip) { messagesArray in
+                guard let messagesArray = messagesArray else {
+                    completion(skip)
+                    return
+                }
+                if messagesArray.count < self.pageSize {
+                    completion(skip)
+                } else {
+                    skip += self.pageSize
+                    fetchPage()
+                }
+            }
+        }
+        fetchPage()
+    }
+
+    func loadLatestFirst(roomId: Int) {
+        findLastPage(roomId: roomId) { lastSkip in
             DispatchQueue.main.async {
-                self.messages = messagesArray.compactMap { dict in
+                self.discoveredTotal = lastSkip + self.pageSize
+                self.latestPageSkip = lastSkip
+                self.fetchMessages(roomId: roomId, take: self.pageSize, skip: lastSkip) {
+                    // Optionally fetch previous page for context
+                    if lastSkip > 0 {
+                        let prevSkip = max(0, lastSkip - self.pageSize)
+                        self.fetchMessages(roomId: roomId, take: self.pageSize, skip: prevSkip, prepend: true)
+                    }
+                }
+            }
+        }
+    }
+
+    func loadOlder(roomId: Int) {
+        guard let total = discoveredTotal else { return }
+        let nextSkip = max(0, latestPageSkip - pageSize)
+        if nextSkip < 0 || nextSkip == latestPageSkip {
+            return
+        }
+        fetchMessages(roomId: roomId, take: pageSize, skip: nextSkip, prepend: true) {
+            self.latestPageSkip = nextSkip
+        }
+    }
+
+    func fetchMessages(for roomId: Int) {
+        fetchMessages(roomId: roomId, take: pageSize, skip: 0)
+    }
+
+    private func fetchMessages(roomId: Int, take: Int, skip: Int, prepend: Bool = false, completion: (() -> Void)? = nil) {
+        SocketService.shared.fetchMessages(roomId: roomId, take: take, skip: skip) { messagesArray in
+            guard let messagesArray = messagesArray else {
+                completion?()
+                return
+            }
+
+            DispatchQueue.main.async {
+                let newMessages = messagesArray.compactMap { dict in
                     if let jsonData = try? JSONSerialization.data(withJSONObject: dict),
                        let message = try? JSONDecoder().decode(Message.self, from: jsonData) {
                         return message
                     }
                     return nil
                 }
+                .sorted {
+                    guard let d0 = self.parseISO8601($0.createdAt), let d1 = self.parseISO8601($1.createdAt) else {
+                        return $0.createdAt < $1.createdAt
+                    }
+                    return d0 < d1
+                }
+
+                let existingIDs = Set(self.messages.map { $0.id })
+                let filteredNew = newMessages.filter { !existingIDs.contains($0.id) }
+
+                if prepend {
+                    self.messages = (filteredNew + self.messages).sorted {
+                        guard let d0 = self.parseISO8601($0.createdAt), let d1 = self.parseISO8601($1.createdAt) else {
+                            return $0.createdAt < $1.createdAt
+                        }
+                        return d0 < d1
+                    }
+                } else {
+                    self.messages = (self.messages + filteredNew).sorted {
+                        guard let d0 = self.parseISO8601($0.createdAt), let d1 = self.parseISO8601($1.createdAt) else {
+                            return $0.createdAt < $1.createdAt
+                        }
+                        return d0 < d1
+                    }
+                }
+                completion?()
             }
         }
     }


### PR DESCRIPTION
## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- Comment 모델에 deleted가 없었고 댓글 불러오는 함수랑 대댓글 함수에 deleted 상태를 고려하지 않아서 삭제된 댓글도 그대로 렌더링됨 -> 서버에서 삭제는 되고 있었는데 화면에 남아 보이는..
- 소프트 삭제된 댓글 숨김 처리 : 서버가 deleted를 true로 내려주는 댓글을 목록/대댓글 트리에서 표시하지 않도록 필터링

## 💻 주요 코드 설명
<!-- 코드 설명 없으면 제목까지 지워주세요! -->
`CommentViewModel.swift`
- 댓글 목록/대댓글 트리에서 삭제 댓글 제외
```swift
// 댓글 목록 재조회 시 soft-delete 제외
self.comments = result.filter { !($0.deleted ?? false) }

// 대댓글 계산 시에도 제외
func replies(for parentId: Int?) -> [Comment] {
    comments.filter { $0.parentId == parentId && !($0.deleted ?? false) }
}
```