### PR TITLE
[feat] 채팅 내용 불러오기, 채팅 번역, 복사/붙여넣기/신고하기 버튼 추가

### DIFF
--- a/worlds-fe-v20.xcodeproj/project.pbxproj
+++ b/worlds-fe-v20.xcodeproj/project.pbxproj
@@ -307,7 +307,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0.3;
-				PRODUCT_BUNDLE_IDENTIFIER = "org.kibwa.worlds-fe-v20";
+				PRODUCT_BUNDLE_IDENTIFIER = "org.kibwa.lde.worlds-fe-v20";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
@@ -346,7 +346,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0.3;
-				PRODUCT_BUNDLE_IDENTIFIER = "org.kibwa.worlds-fe-v20";
+				PRODUCT_BUNDLE_IDENTIFIER = "org.kibwa.lde.worlds-fe-v20";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;

--- a/worlds-fe-v20/Info.plist
+++ b/worlds-fe-v20/Info.plist
@@ -28,18 +28,8 @@
 	<string>$(API_SIGNUP_URL)</string>
 	<key>APIUserInfoURL</key>
 	<string>$(API_USER_INFO_URL)</string>
-	<key>APIOCRURL</key>
-	<string>$(API_OCR_URL)</string>
-	<key>APIOCRSolutionURL</key>
-	<string>$(API_OCR_SOLUTION_URL)</string>
-	<key>APIMyQuestionURL</key>
-	<string>$(API_MY_QUESTION_URL)</string>
-	<key>APIDeleteAccountURL</key>
-	<string>$(API_DELETE_ACCOUNT_URL)</string>
 	<key>CFBundleIconName</key>
 	<string>AppIcon</string>
-	<key>ITSAppUsesNonExemptEncryption</key>
-	<false/>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>

--- a/worlds-fe-v20/ViewModels/ChatViewModel.swift
+++ b/worlds-fe-v20/ViewModels/ChatViewModel.swift
@@ -14,11 +14,32 @@ class ChatViewModel: ObservableObject {
     // 날짜별로 메시지 그룹화
     var groupedMessages: [String: [Message]] {
         let grouped = Dictionary(grouping: messages) { message in
-            formatDateOnly(from: message.createdAt)
+            let dateKey = formatDateOnly(from: message.createdAt)
+            return dateKey.isEmpty ? "unknown date" : dateKey
         }
         return grouped.mapValues { group in
-            group.sorted(by: { $0.createdAt < $1.createdAt })
+            group.sorted { 
+                guard let date0 = parseISO8601($0.createdAt), let date1 = parseISO8601($1.createdAt) else {
+                    return $0.createdAt < $1.createdAt
+                }
+                return date0 < date1
+            }
         }
+    }
+
+    private let pageSize = 20
+    private var latestPageSkip: Int = 0
+    private var discoveredTotal: Int?
+
+    private func parseISO8601(_ s: String) -> Date? {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let date = formatter.date(from: s) {
+            return date
+        }
+        // fallback without fractional seconds
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter.date(from: s)
     }
 
     private func formatDateOnly(from dateString: String) -> String {
@@ -36,11 +57,8 @@ class ChatViewModel: ObservableObject {
     func connectAndJoin(chatId: Int) {
         SocketService.shared.connect()
         SocketService.shared.joinRoom(roomId: chatId)
-        SocketService.shared.onReceiveMessage { [weak self] message in
-            DispatchQueue.main.async {
-                self?.messages.append(message)
-            }
-        }
+        // 리스너 등록 (로그 포함)
+        onReceiveMessage()
     }
     
     func sendMessage(chatId: Int, userId: Int, content: String) {
@@ -89,19 +107,112 @@ class ChatViewModel: ObservableObject {
             }
         }
     }
-    
-    func fetchMessages(for roomId: Int) {
-        SocketService.shared.fetchMessages(roomId: roomId) { messagesArray in
-            guard let messagesArray = messagesArray else { return }
-            
+
+    func seed(initialMessages: [Message]) {
+        DispatchQueue.main.async {
+            let existingIDs = Set(self.messages.map { $0.id })
+            let newMessages = initialMessages.filter { !existingIDs.contains($0.id) }
+            self.messages.append(contentsOf: newMessages)
+            self.messages.sort {
+                guard let d0 = self.parseISO8601($0.createdAt), let d1 = self.parseISO8601($1.createdAt) else {
+                    return $0.createdAt < $1.createdAt
+                }
+                return d0 < d1
+            }
+        }
+    }
+
+    func findLastPage(roomId: Int, completion: @escaping (Int) -> Void) {
+        var skip = 0
+        func fetchPage() {
+            SocketService.shared.fetchMessages(roomId: roomId, take: pageSize, skip: skip) { messagesArray in
+                guard let messagesArray = messagesArray else {
+                    completion(skip)
+                    return
+                }
+                if messagesArray.count < self.pageSize {
+                    completion(skip)
+                } else {
+                    skip += self.pageSize
+                    fetchPage()
+                }
+            }
+        }
+        fetchPage()
+    }
+
+    func loadLatestFirst(roomId: Int) {
+        findLastPage(roomId: roomId) { lastSkip in
             DispatchQueue.main.async {
-                self.messages = messagesArray.compactMap { dict in
+                self.discoveredTotal = lastSkip + self.pageSize
+                self.latestPageSkip = lastSkip
+                self.fetchMessages(roomId: roomId, take: self.pageSize, skip: lastSkip) {
+                    // Optionally fetch previous page for context
+                    if lastSkip > 0 {
+                        let prevSkip = max(0, lastSkip - self.pageSize)
+                        self.fetchMessages(roomId: roomId, take: self.pageSize, skip: prevSkip, prepend: true)
+                    }
+                }
+            }
+        }
+    }
+
+    func loadOlder(roomId: Int) {
+        guard let total = discoveredTotal else { return }
+        let nextSkip = max(0, latestPageSkip - pageSize)
+        if nextSkip < 0 || nextSkip == latestPageSkip {
+            return
+        }
+        fetchMessages(roomId: roomId, take: pageSize, skip: nextSkip, prepend: true) {
+            self.latestPageSkip = nextSkip
+        }
+    }
+
+    func fetchMessages(for roomId: Int) {
+        fetchMessages(roomId: roomId, take: pageSize, skip: 0)
+    }
+
+    private func fetchMessages(roomId: Int, take: Int, skip: Int, prepend: Bool = false, completion: (() -> Void)? = nil) {
+        SocketService.shared.fetchMessages(roomId: roomId, take: take, skip: skip) { messagesArray in
+            guard let messagesArray = messagesArray else {
+                completion?()
+                return
+            }
+
+            DispatchQueue.main.async {
+                let newMessages = messagesArray.compactMap { dict in
                     if let jsonData = try? JSONSerialization.data(withJSONObject: dict),
                        let message = try? JSONDecoder().decode(Message.self, from: jsonData) {
                         return message
                     }
                     return nil
                 }
+                .sorted {
+                    guard let d0 = self.parseISO8601($0.createdAt), let d1 = self.parseISO8601($1.createdAt) else {
+                        return $0.createdAt < $1.createdAt
+                    }
+                    return d0 < d1
+                }
+
+                let existingIDs = Set(self.messages.map { $0.id })
+                let filteredNew = newMessages.filter { !existingIDs.contains($0.id) }
+
+                if prepend {
+                    self.messages = (filteredNew + self.messages).sorted {
+                        guard let d0 = self.parseISO8601($0.createdAt), let d1 = self.parseISO8601($1.createdAt) else {
+                            return $0.createdAt < $1.createdAt
+                        }
+                        return d0 < d1
+                    }
+                } else {
+                    self.messages = (self.messages + filteredNew).sorted {
+                        guard let d0 = self.parseISO8601($0.createdAt), let d1 = self.parseISO8601($1.createdAt) else {
+                            return $0.createdAt < $1.createdAt
+                        }
+                        return d0 < d1
+                    }
+                }
+                completion?()
             }
         }
     }


### PR DESCRIPTION
## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 채팅 메시지 불러오기 로직 수정
- 채팅 번역하기/원문보기 토글 버튼 추가
- 말풍선 길게 누르면 복사, 붙여넣기, 신고하기 컨텍스트 메뉴 표시
- 채팅방 상단 우측 메뉴 버튼 추가
<img width="150" height="400" alt="IMG_5098" src="https://github.com/user-attachments/assets/fb2ad9a0-d9fb-4f70-be94-b65a5182a796" /> 
<img width="150" height="400" alt="IMG_5099" src="https://github.com/user-attachments/assets/abaa49ba-61f8-49e6-9b38-7d1cfc017ef7" /> 
<img width="150" height="400" alt="IMG_5101" src="https://github.com/user-attachments/assets/c8f2eb2c-0ad0-44f2-a810-c6f27e789fee" />

## 💻 주요 코드 설명

`ChatViewModel.swift`
- findLastPage 메서드로 전체 페이지 수를 계산해 최신 20개부터 로딩
- loadLatestFirst 메서드로 마지막 페이지부터 로딩하여 최신 20개 메시지를 우선 표시
- loadOlder 메서드로 스크롤이 최상단에 닿으면 이전 페이지 데이터를 불러와 prepend


## 💬 공유사항 to 리뷰어

- 신고하기, 상대 프로필, OCR 기록, 채팅방 나가기 모두 기능 구현 없이 UI만 만들어 놓은 상태입니다
