### PR TITLE
[feat] 채팅 읽은 처리 로직 구현 및 읽지 않은 메세지 표시

### DIFF
--- a/worlds-fe-v20/Models/Chat.swift
+++ b/worlds-fe-v20/Models/Chat.swift
@@ -16,9 +16,10 @@ struct ChatRoom: Identifiable, Codable {
     let userA: ChatUser
     let userB: ChatUser
     let messages: [Message]
+    var unreadCount: Int?
 
     var name: String {
-        return userB.userName // 예시. 본인이 userA이면 상대방 이름 반환
+        return userB.userName
     }
 
     var preview: String {

--- a/worlds-fe-v20/Services/SocketService.swift
+++ b/worlds-fe-v20/Services/SocketService.swift
@@ -67,18 +67,13 @@ class SocketService {
         socket.emit(Event.joinRoom, ["roomId": roomId, "userId": userId])
     }
 
-    /// 주어진 userId에 해당하는 채팅방 목록을 REST API로 요청
+    /// 채팅방 목록을 REST API로 요청 (JWT 기반)
     /// - Parameters:
     ///   - completion: 응답으로 받은 채팅방 목록 배열(JSON)을 반환하는 클로저
     func fetchChatRooms(completion: @escaping ([ChatRoom]?) -> Void) {
-        guard let userId = currentUserId else {
-            print("No CurrentUserId found in UserDefaults")
-            completion(nil)
-            return
-        }
-        print("🔍 fetchChatRooms with userId:", userId)
+        print("🔍 fetchChatRooms (JWT)")
         guard let baseUrl = Bundle.main.object(forInfoDictionaryKey: "APIBaseURL") as? String,
-              let url = URL(string: "\(baseUrl)/chat/chatrooms/\(userId)") else {
+              let url = URL(string: "\(baseUrl)/chat/chatrooms") else {
             print("Invalid APIBaseURL or URL format")
             completion(nil)
             return
@@ -451,7 +446,12 @@ extension SocketService {
         req.httpMethod = "POST"
         req.setValue("application/json", forHTTPHeaderField: "Content-Type")
         req.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
-        let body = ["token": token]
+        let rawToken = token
+        let cleanedToken = rawToken.trimmingCharacters(in: .whitespacesAndNewlines)
+        print("🔎 claim raw token:", rawToken)
+        print("🔎 claim cleaned token:", cleanedToken)
+        print("🔎 raw == cleaned?", rawToken == cleanedToken)
+        let body = ["token": cleanedToken]
         req.httpBody = try? JSONSerialization.data(withJSONObject: body)
 
         URLSession.shared.dataTask(with: req) { data, resp, err in

--- a/worlds-fe-v20/ViewModels/ChatListViewModel.swift
+++ b/worlds-fe-v20/ViewModels/ChatListViewModel.swift
@@ -13,26 +13,34 @@ class ChatListViewModel: ObservableObject {
     private var cancellables = Set<AnyCancellable>()
 
     func fetchChatRooms(for userId: Int) {
+        // NOTE: 서버가 JWT로 사용자 식별하므로 userId는 더 이상 경로에 포함하지 않습니다.
         guard let baseURL = Bundle.main.object(forInfoDictionaryKey: "APIBaseURL") as? String,
-              let url = URL(string: "\(baseURL)/chatrooms/\(userId)") else {
+              let url = URL(string: "\(baseURL)/chat/chatrooms") else {
             print("Invalid URL or missing APIBaseURL")
             return
         }
 
-        URLSession.shared.dataTaskPublisher(for: url)
+        guard let accessToken = UserDefaults.standard.string(forKey: "accessToken") else {
+            print("❌ accessToken 없음: 채팅방 목록을 불러올 수 없습니다.")
+            return
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+
+        URLSession.shared.dataTaskPublisher(for: request)
             .map(\.data)
             .decode(type: [ChatRoom].self, decoder: JSONDecoder())
             .receive(on: DispatchQueue.main)
             .sink(receiveCompletion: { completion in
-                switch completion {
-                case .finished:
-                    break
-                case .failure(let error):
-                    print("Error fetching chat rooms: \(error)")
+                if case let .failure(error) = completion {
+                    print("Error fetching chat rooms:", error)
                 }
             }, receiveValue: { [weak self] rooms in
                 self?.chatRooms = rooms
             })
-            .store(in: &cancellables)
+            .store(in: &self.cancellables)
     }
 }


### PR DESCRIPTION
## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 메시지 읽음 처리 로직 구현
- 각 채팅방 목록에서 읽지 않은 새로운 메시지 수 표시
<img width="150" height="400" alt="IMG_5114" src="https://github.com/user-attachments/assets/2f6a3d91-5ca8-42ea-a827-81cdb3963e63" />


## 💻 주요 코드 설명
<!-- 코드 설명 없으면 제목까지 지워주세요! -->
`SocketService.swift`
- 단일/일괄 메시지 읽음 처리를 위한 소켓 이벤트 emit 구현
```swift
/// 단일 메시지 읽음 처리(소켓 emit)
func emitMessageRead(roomId: Int, messageId: Int) {
    guard let userId = currentUserId else {
        return
    }
    let payload: [String: Any] = [
        "roomId": roomId,
        "userId": userId,
        "messageIds": [messageId]
    ]
    socket.emit(Event.readMessage, payload)
}

/// 여러 메시지 일괄 읽음 처리(소켓 emit)
func emitMessagesRead(roomId: Int, messageIds: [Int]) {
    guard let userId = currentUserId, !messageIds.isEmpty else { return }
    let payload: [String: Any] = [
        "roomId": roomId,
        "userId": userId,
        "messageIds": messageIds
    ]
    socket.emit(Event.readMessage, payload)
}
```
`ChatListView.swift`
- 안읽은 메시지 개수 표시 로직을 로컬 계산 기반으로 함
- 새 메시지 수신 시 unreadCount 업데이트
- 메시지 읽음 처리 시 unreadCount 초기화

## 💬 공유사항 to 리뷰어
- 서버에서 불러오는 안읽은 메시지 개수가 바로 반영이 안 되는건지 잘 안 맞아서 일단 로컬을 기반으로 계산하는 로직으로 했음! 이렇게 하면 되긴해서 추후에 얘기해보면 될듯
